### PR TITLE
Fix messy resume footer on mobile

### DIFF
--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -234,7 +234,7 @@ const title = `${SITENAME} — Resume`;
       <div class="resume-footer">
         <div class="resume-live">
           <p>
-            🖨️ <button type="button" id="print-button" class="print-link">Use the built-in print functionality of your browser or click this to get a clean A4 paper or a PDF.</button>.
+            🖨️ <button type="button" id="print-button" class="print-link">Use the built-in print functionality of your browser or click this to get a clean A4 paper or a PDF.</button>
           </p>
           <button class="theme-toggle" type="button" aria-label="Toggle theme">
             <span class="theme-toggle-dark" aria-hidden="true">🌙</span>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -234,7 +234,7 @@ const title = `${SITENAME} — Resume`;
       <div class="resume-footer">
         <div class="resume-live">
           <p>
-            🖨️ <button type="button" id="print-button" class="print-link">Use the built-in print functionality of your browser or click this to get a clean A4 paper or a PDF.</button>
+            <button type="button" id="print-button" class="print-link">🖨️ Use the built-in print functionality of your browser or click this to get a clean A4 paper or a PDF.</button>
           </p>
           <button class="theme-toggle" type="button" aria-label="Toggle theme">
             <span class="theme-toggle-dark" aria-hidden="true">🌙</span>

--- a/src/styles/resume.css
+++ b/src/styles/resume.css
@@ -163,6 +163,15 @@ body.resume-page {
   .resume-footer {
     margin-top: 0 !important;
   }
+
+  .resume-live {
+    flex-direction: column;
+  }
+
+  .resume-live .theme-toggle {
+    align-self: center;
+    margin-top: 1em;
+  }
 }
 
 .resume-content h2 {

--- a/src/styles/resume.css
+++ b/src/styles/resume.css
@@ -254,7 +254,7 @@ body.resume-page {
 
 .resume-live {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1em;
 }
@@ -274,4 +274,5 @@ body.resume-page {
   font: inherit;
   color: inherit;
   cursor: pointer;
+  text-align: left;
 }


### PR DESCRIPTION
## Summary

The resume footer rendered messily on mobile due to three independent issues, all visible in the reported screenshot:

- **Centered button text.** `.print-link` did not override the browser-default `text-align: center` on `<button>`, so the wrapped print message rendered center-aligned.
- **Orphan period.** `resume.astro` had `</button>.` after a button whose text already ended with `PDF.`, producing a duplicate `..` that wrapped to its own line on narrow screens.
- **Theme toggle floating into the text.** `.resume-live` used `align-items: center`, so on mobile (where the print message wraps to multiple lines) the 🌙 toggle was vertically centered against the tall paragraph and appeared in the middle of the text.

Fixes:
- `src/styles/resume.css`: add `text-align: left` to `.print-link`, switch `.resume-live` to `align-items: flex-start` so the toggle sits at the top-right corner of the footer row.
- `src/pages/resume.astro`: drop the stray `.` after `</button>`.

## Test plan

- [ ] Visit `/resume` on a narrow viewport (≤ 42em) and confirm the print message is left-aligned, the trailing period is gone, and 🌙 sits at the top-right of the footer.
- [ ] Visit `/resume` on desktop and confirm the footer still reads as a single line with the toggle on the right.
- [ ] Toggle dark mode and reprint preview to confirm no regression in print styling.

---
_Generated by [Claude Code](https://claude.ai/code/session_013wwtAXufKeUhdpZ4sJaGYn)_