### PR TITLE
Fix white flash on page transitions

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -56,18 +56,21 @@ const ogImage = cover ? `${SITE_URL}/${cover}` : undefined;
 
     <script is:inline>
       (() => {
-        const applyTheme = () => {
+        const getTheme = () => {
           try {
             const stored = localStorage.getItem('theme')
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-            const theme = stored ?? (prefersDark ? 'dark' : 'light')
-            document.documentElement.setAttribute('data-theme', theme)
+            return stored ?? (prefersDark ? 'dark' : 'light')
           } catch {
-            // localStorage unavailable; leave default (light).
+            return 'light'
           }
         }
-        applyTheme()
-        document.addEventListener('astro:after-swap', applyTheme)
+        document.documentElement.setAttribute('data-theme', getTheme())
+        // Set the attribute on the incoming document before Astro swaps it in,
+        // otherwise the View Transitions snapshot captures a light-mode frame.
+        document.addEventListener('astro:before-swap', (event) => {
+          event.newDocument.documentElement.setAttribute('data-theme', getTheme())
+        })
       })()
     </script>
 

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -28,18 +28,21 @@ const title = `${SITENAME} — Resume`;
 
     <script is:inline>
       (() => {
-        const applyTheme = () => {
+        const getTheme = () => {
           try {
             const stored = localStorage.getItem('theme')
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-            const theme = stored ?? (prefersDark ? 'dark' : 'light')
-            document.documentElement.setAttribute('data-theme', theme)
+            return stored ?? (prefersDark ? 'dark' : 'light')
           } catch {
-            // localStorage unavailable; leave default (light).
+            return 'light'
           }
         }
-        applyTheme()
-        document.addEventListener('astro:after-swap', applyTheme)
+        document.documentElement.setAttribute('data-theme', getTheme())
+        // Set the attribute on the incoming document before Astro swaps it in,
+        // otherwise the View Transitions snapshot captures a light-mode frame.
+        document.addEventListener('astro:before-swap', (event) => {
+          event.newDocument.documentElement.setAttribute('data-theme', getTheme())
+        })
       })()
     </script>
 


### PR DESCRIPTION
## Summary

- The dark-mode init script reapplied `data-theme` on `astro:after-swap`, which fires *after* the View Transitions API has already snapshotted the new page.
- Because the incoming server-rendered HTML ships without `data-theme`, the new snapshot captured a light-mode frame, and the 150ms cross-fade revealed it as a brief white flash.
- Moved the reapply to `astro:before-swap` and mutated `event.newDocument.documentElement` so the attribute is in place before the snapshot is taken. Same change in `Base.astro` and `resume.astro` (which has its own head block).

## Test plan

- [x] On a dark-mode session, navigate between `/`, `/posts`, `/about`, `/resume`, and into a post — confirm no white flash mid-transition.
- [x] On a light-mode session, navigate between the same pages — confirm transitions still cross-fade cleanly with no dark flash.
- [x] Toggle the theme from the footer button, then navigate — the new page should respect the toggled theme without flashing.
- [x] Hard-reload each page directly to verify initial-load theme detection (localStorage + `prefers-color-scheme`) still works.

https://claude.ai/code/session_011XorkyerumSgL98pYHTqKx

---
_Generated by [Claude Code](https://claude.ai/code/session_011XorkyerumSgL98pYHTqKx)_