### PR TITLE
Replace three-dot section separator with asterism

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -59,9 +59,7 @@ hr {
 }
 
 hr:before {
-  content: '...';
-  letter-spacing: 0.7em;
-  margin-right: -0.7em;
+  content: '⁂';
 }
 
 h1,

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -54,7 +54,7 @@ hr {
   font-size: 120%;
   font-weight: bold;
   margin: 2em 0;
-  color: var(--color-faded);
+  color: var(--color-faded-max);
   height: 1em;
 }
 


### PR DESCRIPTION
## Summary
- Swap the three-dot `<hr>` separator for the asterism character `⁂`
- Drop the now-unneeded `letter-spacing` / `margin-right` tweaks

The asterism is the classic typographic mark for a section break in print and reads as more intentional alongside the Fraunces serif headings.

## Test plan
- [ ] Open `https://blog.lucas.zip/prisma-graphql-api` (or run the dev server) and confirm the separator renders as `⁂` centered between sections
- [ ] Verify color and spacing still match the surrounding text in both light and dark themes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Un1ySo1NzHpun3UKuvjUXd)_