### PR TITLE
Fix theme toggle sometimes ignoring clicks during navigation

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -71,6 +71,22 @@ const ogImage = cover ? `${SITE_URL}/${cover}` : undefined;
         document.addEventListener('astro:before-swap', (event) => {
           event.newDocument.documentElement.setAttribute('data-theme', getTheme())
         })
+        // Delegate from document so the handler survives view-transition swaps
+        // of the toggle button (otherwise clicks landing between astro:after-swap
+        // and astro:page-load hit a button with no listener).
+        document.addEventListener('click', (event) => {
+          const target = event.target
+          if (!(target instanceof Element)) return
+          if (!target.closest('.theme-toggle')) return
+          const current = document.documentElement.getAttribute('data-theme')
+          const next = current === 'dark' ? 'light' : 'dark'
+          document.documentElement.setAttribute('data-theme', next)
+          try {
+            localStorage.setItem('theme', next)
+          } catch {
+            // localStorage unavailable; toggle still works for the session.
+          }
+        })
       })()
     </script>
 
@@ -124,20 +140,5 @@ const ogImage = cover ? `${SITE_URL}/${cover}` : undefined;
       </ul>
     </div>
 
-    <script>
-      document.addEventListener('astro:page-load', () => {
-        const button = document.querySelector<HTMLButtonElement>('.theme-toggle')
-        button?.addEventListener('click', () => {
-          const current = document.documentElement.getAttribute('data-theme')
-          const next = current === 'dark' ? 'light' : 'dark'
-          document.documentElement.setAttribute('data-theme', next)
-          try {
-            localStorage.setItem('theme', next)
-          } catch {
-            // localStorage unavailable; toggle still works for the session.
-          }
-        })
-      })
-    </script>
   </body>
 </html>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -43,6 +43,22 @@ const title = `${SITENAME} — Resume`;
         document.addEventListener('astro:before-swap', (event) => {
           event.newDocument.documentElement.setAttribute('data-theme', getTheme())
         })
+        // Delegate from document so the handler survives view-transition swaps
+        // of the toggle button (otherwise clicks landing between astro:after-swap
+        // and astro:page-load hit a button with no listener).
+        document.addEventListener('click', (event) => {
+          const target = event.target
+          if (!(target instanceof Element)) return
+          if (!target.closest('.theme-toggle')) return
+          const current = document.documentElement.getAttribute('data-theme')
+          const next = current === 'dark' ? 'light' : 'dark'
+          document.documentElement.setAttribute('data-theme', next)
+          try {
+            localStorage.setItem('theme', next)
+          } catch {
+            // localStorage unavailable; toggle still works for the session.
+          }
+        })
       })()
     </script>
 
@@ -262,18 +278,6 @@ const title = `${SITENAME} — Resume`;
         document
           .getElementById('print-button')
           ?.addEventListener('click', () => window.print())
-
-        const toggle = document.querySelector<HTMLButtonElement>('.theme-toggle')
-        toggle?.addEventListener('click', () => {
-          const current = document.documentElement.getAttribute('data-theme')
-          const next = current === 'dark' ? 'light' : 'dark'
-          document.documentElement.setAttribute('data-theme', next)
-          try {
-            localStorage.setItem('theme', next)
-          } catch {
-            // localStorage unavailable; toggle still works for the session.
-          }
-        })
       })
     </script>
   </body>


### PR DESCRIPTION
## Summary

- The theme toggle's click handler was registered inside an `astro:page-load` listener. With the View Transitions `<ClientRouter />`, the button DOM is replaced on each navigation, leaving a brief window between `astro:after-swap` (button is in the DOM) and `astro:page-load` (listener is re-attached) where a click lands on a fresh button with no handler — silently doing nothing. This matches the "hard to reproduce, sometimes does nothing" symptom.
- Move the click handler to `document` using event delegation, registered once in the existing head `is:inline` script. Document-level listeners survive view-transition swaps, so the toggle is always live.

## Test plan

- [ ] Open the site, click the moon/sun toggle in the footer — theme flips and persists across reloads.
- [ ] Navigate between pages (Home ↔ About ↔ Resume) several times, then click the toggle immediately after each navigation — it should never be a no-op.
- [ ] Toggle theme, then navigate — the new page renders in the correct theme without a light-mode flash.
- [ ] Disable JS / private mode (no localStorage) — clicking the toggle still flips the theme for the session without errors.

https://claude.ai/code/session_01T6k6R8Wgdjkf5buT4DfmFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6k6R8Wgdjkf5buT4DfmFV)_