### PR TITLE
Add resume link to about page

### DIFF
--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -6,7 +6,8 @@ slug: about
 My name is Lucas Santoni, and I work as a software engineer and tech executive,
 mostly in and around startups and fintech. My work tends to span both sides of
 that: writing code and designing systems, but also hiring, growing teams,
-owning delivery, and shaping the processes that make all of it work.
+owning delivery, and shaping the processes that make all of it work. You can
+find more details on my [resume](/resume).
 
 What I think and write about on this blog is broader. Topics include
 engineering team topologies and processes, developer tooling, teaching and


### PR DESCRIPTION
## Summary
- Link to `/resume` from the end of the first paragraph on the about page so readers have an easy path from the bio to the full resume.

## Test plan
- [ ] Visit `/about` and confirm the new "resume" link in the first paragraph navigates to `/resume`.

https://claude.ai/code/session_016L7oAUJeKycuRQFjn7JWhh

---
_Generated by [Claude Code](https://claude.ai/code/session_016L7oAUJeKycuRQFjn7JWhh)_