### PR TITLE
macos-restic-b2: June 2026 update on prune lock contention

### DIFF
--- a/src/content/posts/macos-restic-b2.md
+++ b/src/content/posts/macos-restic-b2.md
@@ -7,6 +7,22 @@ AMFI, codesigning, DarkWake) that make nightly encrypted offsite backups with
 restic, resticprofile, and Backblaze B2 trickier than they should be."
 ---
 
+**Update, June 2026**: a follow-up on the `prune` / `check` cycle. Restic's
+default `--max-unused` of 5% makes `prune` repack pack files aggressively, and
+on B2 repacking means downloading and re-uploading whole packs. On a heavy week
+that turned into a 6h+ run that held the repository lock well past the `check`
+scheduled an hour later, so `check` couldn't acquire the lock and exited 11
+(restic's "failed to lock repository"). The fix was to stop letting `prune`
+become a marathon: raise `--max-unused` to 10% so it repacks far less, cap each
+run with `--max-repack-size=300M`, and run `prune` daily instead of weekly so
+the work stays small and spread out, with `check` moved off its day. A `prune`
+that had been running 6h+ dropped to ~100 seconds while reclaiming *more*
+space. This is only one way to bound it and the numbers are just an example:
+other strategies work too, like pushing `--max-unused` higher, sizing
+`--max-repack-size` to your link, or matching the `prune` cadence to your
+churn. The Sunday `prune` / `check` schedule and the empty
+`[profiles.default.prune]` section shown further down predate this change.
+
 **Update, May 2026**: a macOS 26.5 update broke this setup soon after I was
 done writing it. I had Claude dig into it for a while and I made some
 experiments, but I couldn't get the pretty Login Items name and the custom icon


### PR DESCRIPTION
Adds a June 2026 update block (newest-first, above the May 2026 one) to the
`macos-restic-b2` post.

## What it covers
A weekly `prune` occasionally ran 6h+ over the high-latency B2 link (restic's
default `--max-unused` of 5% forces aggressive repacking — download + reupload
of whole packs), holding the repository lock past the `check` scheduled an hour
later. `check` then failed to acquire the lock and exited 11.

The fix, as documented in the block: bound `prune` (`--max-unused=10%`,
`--max-repack-size=300M`) and run it daily so the work stays small and spread
out, with `check` moved off `prune`'s day. A prune that had been running 6h+
dropped to ~100s while reclaiming more space. The block also notes these are
just example knobs and other strategies work.

## Notes
- Prose-only change to one Markdown file; no code/schema touched.
- The "Prune cycle" / Sunday-schedule sections lower in the post are left as-is
  and explicitly flagged as predating this change (same convention as the May
  update).
- QA via the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)