### PR TITLE
Add blog post: What actually makes an engineer senior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,26 +82,34 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
       "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
-      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.7",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.7.tgz",
-      "integrity": "sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==",
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
+      "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
-        "@astrojs/yaml2ts": "^0.2.3",
+        "@astrojs/yaml2ts": "^0.2.4",
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@volar/kit": "~2.4.28",
         "@volar/language-core": "~2.4.28",
@@ -143,17 +151,16 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
-      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.0",
-        "@astrojs/prism": "4.0.1",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -161,9 +168,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -172,9 +176,9 @@
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
-      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
@@ -206,13 +210,12 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
-      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^4.4.0",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "is-docker": "^4.0.0",
         "is-wsl": "^3.1.1",
@@ -223,12 +226,12 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-10.0.6.tgz",
-      "integrity": "sha512-Ubd1M77QWqXXluFNL8/ynmfyZCfIUVuL6QRpPXGYOIQ8Dv3QBXM34e0CMig3OgmihSIWNv9sqQHzEHDyDJV9QQ==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-10.0.8.tgz",
+      "integrity": "sha512-usxmHwMEWI+yaYioSB9eFZbmuFKPnMPmQlX2e9PZ3+v79Xo4IFiKVqblspV+CuOE3u/CtgcHdnC9khKjZlbMyA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/internal-helpers": "0.10.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/functions": "^3.4.3",
         "@vercel/nft": "^1.3.2",
@@ -241,13 +244,13 @@
       }
     },
     "node_modules/@astrojs/yaml2ts": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
-      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1970,13 +1973,13 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/primitive": "4.3.0",
+        "@shikijs/types": "4.3.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -1986,26 +1989,26 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
-      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.0.tgz",
+      "integrity": "sha512-hTv/KiFf2tpiqlACPiztGGurEARWIutB8YUhcrA1pUC7VzzwKO+g5crUocrLztrZ5ro5Z4hbXg7bYclETn3gSQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.3.0",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
+        "oniguruma-to-es": "^4.3.6"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
-      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.0.tgz",
+      "integrity": "sha512-1vMdN3gHfnKfLYwecUI2ITJI4RhHt96xEaJumVn7Heb0IlJ8WQMIH0Voak+2j22BpSNKdnOfB/pCTPnPm2gq7A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.3.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -2013,24 +2016,24 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
-      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.0.tgz",
+      "integrity": "sha512-rnlqFbBRSys9bT4gl/5rw9RnS0W/I84ZldXPkO7cvlEMoV85TyF/aU01N7/NbSR776RNLjrJKjfFUXJR6wN1Cg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2"
+        "@shikijs/types": "4.3.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
-      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.0.tgz",
+      "integrity": "sha512-CPkz64PTa5diRW1ggzMZH9VM/du4RNChYgVtgqrFcgruvIybmCvySv8GkiHSczUHXYuuR8TdKEwFx+UnZMpgdg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.3.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -2039,21 +2042,21 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
-      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.0.tgz",
+      "integrity": "sha512-Avgt05YiT+Y3prjIc9lmQxhJzHBcCfR6cjiFW4OyaMBbt2A6trX5rfjUzx+Vj/mE9qpArYjatnqo9XPjQNW/AQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2"
+        "@shikijs/types": "4.3.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
-      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-oc8b9U2SYvofKZk8e/737nIX0qwf6eV2vHFATeObAu7r+mUVpLs8Re0BmVkIjAWAYgkmG/CzLNo7rzuBzRu/wQ==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -2751,15 +2754,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
-      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.9.0",
-        "@astrojs/markdown-remark": "7.1.1",
-        "@astrojs/telemetry": "3.3.1",
+        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
+        "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -2770,17 +2773,19 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
         "flattie": "^1.1.1",
         "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
         "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
         "magic-string": "^0.30.21",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
@@ -2799,7 +2804,6 @@
         "tinyclip": "^0.1.12",
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
-        "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
@@ -2915,6 +2919,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/astro/node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "license": "MIT"
+    },
+    "node_modules/astro/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/astrojs-compiler-sync": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
@@ -2984,9 +3000,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3366,9 +3382,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3392,12 +3408,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3885,9 +3895,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -3911,9 +3921,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3922,7 +3932,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -4095,6 +4106,21 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-slugger": {
@@ -4545,9 +4571,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6324,6 +6360,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -6554,17 +6599,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
-      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.0.tgz",
+      "integrity": "sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/core": "4.3.0",
+        "@shikijs/engine-javascript": "4.3.0",
+        "@shikijs/engine-oniguruma": "4.3.0",
+        "@shikijs/langs": "4.3.0",
+        "@shikijs/themes": "4.3.0",
+        "@shikijs/types": "4.3.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -6598,9 +6643,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -6730,9 +6775,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.17",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
+      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -6837,26 +6882,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6888,7 +6913,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7265,12 +7290,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -7689,6 +7714,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -3,119 +3,139 @@ title: "What actually makes an engineer senior"
 slug: what-makes-an-engineer-senior
 date: 2026-06-26
 description: "Tenure isn't seniority, and seniority isn't management. After six
-years building an engineering team from one person to thirty at a fintech,
-here's what I think seniority actually is: the ability to reduce uncertainty for
-the people around you."
+years building an engineering team from one person to thirty at a fintech, here's
+what I've come to believe seniority is: the ability to reduce uncertainty for the
+people around you."
 ---
-
-Is a developer with ten years of experience senior?
-
-Most people answer yes without thinking about it. Ten years is a long time. They
-must have seen a lot, learned a lot, earned the title. That instinct is exactly
-the problem. We treat seniority as something that accumulates on its own, like
-interest in a savings account, and it doesn't.
 
 This post is roughly a written version of a talk I gave in French a while back,
 which you can [watch here](https://www.youtube.com/watch?v=5I6Ozt30jI4&t=920s) if
 that's your language.
 
-I joined a fintech startup six years ago as a very early employee, and over the
-next stretch I built the engineering team from scratch, from one engineer to more
-than thirty. I hired seniors, I mislabeled people as seniors, I watched some
-"juniors" run circles around people with twice their tenure, and I made most of
-the classic mistakes myself. Along the way I changed my mind about what the word
-even means. Here's where I landed.
+---
+
+Is a developer with ten years of experience senior?
+
+I think most people would answer "yes" without really thinking about it. Ten
+years is a long time after all. They must have seen a lot, learned a lot,
+earned the title. That instinct is exactly the problem. We tend to treat
+seniority as something that accumulates on its own, like interest in a savings
+account... But I don't think it does!
+
+I joined a fintech startup as CTO six years ago, when the company was only four
+people (including me!). I built the engineering team from scratch, from one
+engineer to more than thirty. I hired seniors, I mislabeled people as seniors,
+I watched some "juniors" run circles around people with twice their tenure, and
+I made a lot of mistakes myself. Along the way I changed my mind about what the
+word even means.
+
+**None of what follows is a framework or a rule.** It's just what I learned the hard
+way, written down for the version of me who was about to make his first hire and
+had no idea what he was looking for. If you're building or scaling a team right
+now, I hope some of it saves you a mistake or two. But it's one person's
+experience, and your context will differ from mine in ways that matter. Take what
+resonates and leave the rest.
 
 ## Time in the chair is not the same as growth
 
 Someone who has been around longer does have more. More context, more scar
-tissue, more history with the codebase and the people and the decisions nobody
+tissue, more history with the codebase or the people and the decisions nobody
 remembers making. That's real, and it's valuable. But it is not the same thing
 as having gotten better at the craft.
 
-It helps to split what a person carries into two buckets. The first is
-contextual value: knowing why the billing service has that weird carve-out,
+It helps to split what a person carries into two buckets. **The first is
+contextual value**: knowing why some service has that weird carve-out,
 remembering which client the retry logic was added for, knowing who to ask when
-the legacy import breaks. This is precious. It keeps the lights on. But it is
-bound to one environment. It evaporates the day they leave.
+the legacy import breaks: this is precious. But it is bound to one environment
+so it evaporates the day this person leaves.
 
-The second is transferable competence: the part they take with them out the
-door. The judgment, the patterns, the ability to walk into a new system and a
-new team and be useful within weeks. When we say someone is senior, we usually
-mean we're impressed by their contextual value and we quietly assume the
-transferable competence is there too. Often it isn't.
+**The second is transferable competence**: the part they take with them out the
+door. The judgment, the patterns, the ability to walk into a new system and /
+or a new team and be useful within days or weeks. When we say someone is
+senior, we usually mean _we're impressed by their contextual value and we
+quietly assume the transferable competence is there too_. But from my
+experience, it's not always the case.
 
-Picture two developers. One has eight years at a large company, working on a
+Picture two developers... One has eight years at a large company, working on a
 narrow slice of a big system, with well-defined specs handed down and a clear
 lane to stay in. The other has three years at an early-stage startup, making
-structural architecture decisions with incomplete information, getting paged at
-2am when production falls over, and scaling systems that were very much not built
-to be scaled. Who has more transferable competence?
+structural architecture decisions with incomplete information, getting ping'd
+late when production falls over, and scaling systems that were very much not
+built to be scaled. Who has more transferable competence between these two
+guys?
 
-I'm not saying the answer is always the second one. The point is that the first
-one's eight years tell you almost nothing on their own. It's not about duration.
-It's about density of experience. Eight years of the same well-specified ticket
+I'm not saying the answer is always the second one. **The point is that the first
+one's eight years tell you almost nothing on their own.** It's not about duration,
+it's about density of experience. Eight years of the same well-specified ticket
 is eight years of one thing. Three years of being thrown into the deep end
 repeatedly is something else entirely.
 
 ## Skill doesn't grow in a straight line
 
-Company career ladders are roughly linear. Junior, mid, senior, lead, and so on,
-each rung a tidy step above the last. Actual competence does not grow that way.
-It moves in jumps and long flat stretches, and the ladder has no idea.
+Company career ladders are roughly linear: junior, mid, senior, lead, and so
+on... each run a tidy step above the last. That's especially true for early
+startups who want to focus on building stuff and tend to delay the moment they
+start to take HR and personal growth matters seriously. But the point is that
+actual competence does not grow that way. You don't magically become "mid"
+after two years and "senior" after five.
 
-There's a saying that gets repeated because it keeps being true. Some people
-don't have ten years of experience. They have one year of experience, repeated
-ten times. The first year they learned the stack, shipped features, stopped
-breaking things. Years two through ten they did that same year again, a little
-faster, a little smoother, but not fundamentally harder.
+There's a saying that some people don't have ten years of experience; they have
+one year of experience, repeated ten times. The first year they learned the
+stack, shipped features, stopped breaking things. Years two through ten they
+did that same year again, a little faster, a little smoother, but not
+fundamentally harder or different.
 
 This is the plateau, and most developers reach some version of it. They ship,
-they don't break prod, they know their tools. Life is fine up there. And here's
-the part people don't like to say out loud: usually there's no reason to leave.
-The work gets done, the paycheck arrives, nobody is demanding more. Not everyone
-is in love with this craft, and that is completely fine. Not every job has to be
-a calling. But comfort and growth are bad roommates. They don't share a space
-for long.
+they don't break prod, they know their tools. Life is fine up there and there's
+no reason to challenge the _status quo_. The work gets done, the paycheck
+arrives, nobody is demanding more. Not everyone is in love with this craft, and
+that is completely fine. Not every job has to be a calling. But comfort and
+growth are bad roommates.
 
 What actually moves you off the plateau is the stuff that feels bad in the
-moment. Reading code you didn't write and wouldn't have written that way.
-Stepping into a problem domain you don't master and feeling like a beginner
-again. Taking the project where you're clearly the least qualified person in the
-room. Growth lives in that discomfort. The day everything at work feels easy is
-the day you've stopped getting better.
+moment: reading code you didn't write and wouldn't have written that way,
+stepping into a problem domain you don't master and feeling like a beginner
+again, taking the project where you're clearly the least qualified person in
+the room, etc. Growth lives in that discomfort and growth will increase your
+seniority level.
 
 ## Seniority is not management
 
-Here is one of the most expensive mistakes a growing company makes, and I've
-both committed it and cleaned up after it. "She's been here five years, she's
-senior, let's give her a team." It's a great way to lose a strong engineer and
-manufacture a struggling manager in a single move.
+A very obvious and expensive mistake I've done myself is to promote great
+engineers to management position. "He's been here five years, he's senior,
+let's give him a team." It's a great way to lose a strong engineer and
+manufacture a struggling manager in a single move...
 
 Management is not a promotion you earn by being good at engineering. It's a
 career change. It runs on a different set of skills that nobody acquires by
 writing good code: giving feedback that lands, sitting in conflict without
-flinching, prioritizing other people's work, recruiting, and absorbing pressure
-from above so your team can keep their heads down. Some excellent engineers want
-none of that, and forcing it on them punishes everyone.
+flinching, prioritizing other people's work, recruiting, absorbing pressure
+from above so your team can keep their heads down and a ton of other things.
+Some excellent engineers want none of that and / or are bad a it, and forcing
+it on them punishes everyone.
 
 The healthier model has two tracks. There's the management track: tech lead,
 engineering manager, VP of Engineering. And there's the individual contributor
-track: senior engineer, staff engineer, principal engineer. Both are legitimate.
-Both go far, in title and in compensation. And both require leadership, which is
-the part people miss when they assume IC means "just codes, quietly."
+track: senior engineer, staff engineer, principal engineer. Both are
+legitimate, both go far in title / compensation and both require leadership.
+The difference is the kind of leadership:
 
-The difference is the kind of leadership. A manager has positional leadership.
-They have a team, they're responsible for people, the authority comes with the
-box on the org chart. A staff engineer has leadership of influence. They have
-authority over no one, and they still shape the technical direction, align teams
-that are drifting apart, and unblock situations that would otherwise stall for
-weeks. They lead because people choose to follow their judgment, not because
-they have to.
+* **A manager has positional leadership.** They have a team, they're responsible
+  for people, the authority comes with the box on the org chart.
+* **A staff engineer has leadership of influence.** They have authority over no
+  one, and they still shape the technical direction, align teams that are
+  drifting apart, and unblock situations that would otherwise stall for weeks.
+  They lead because people choose to follow their judgment, not because they
+  have to.
 
-So seniority does not mean management. But, and this is the nuance that matters,
-seniority does mean leadership in some form. If your influence ends at the edge
-of your own keyboard, you're not senior yet, whatever the title says.
+Fortunately, most well structured companies operate on some version of this
+dual track framework. But when your startup is small and everyone does a bit of
+everything, it's easy to confuse seniority and management.
+
+So seniority does NOT mean management. But, and this is the nuance that
+matters, **seniority does mean leadership in some form**. If your influence
+ends at the edge of your own keyboard, you're not senior yet, whatever the
+title says.
 
 ## So what is it? Reducing uncertainty.
 
@@ -158,11 +178,16 @@ doesn't.
 
 ## Back to the question
 
-So, is a developer with ten years of experience senior? You can't know from the
-sentence. Ten years tells you how long they've been employed, nothing more.
+So, is a developer with ten years of experience senior? In my experience you
+can't know from the sentence. Ten years tells you how long they've been employed,
+nothing more.
 
-Being senior was never about time, titles, or lines of code. It's about what you
-did with the time. It's whether the people around you face less uncertainty
-because you're there, and whether they leave each interaction a little more
-capable than they came in. That's the whole thing. The years are just the
-container. What you poured into them is what counts.
+For me, being senior was never about time, titles, or lines of code. It's about
+what you did with the time. It's whether the people around you face less
+uncertainty because you're there, and whether they leave each interaction a little
+more capable than they came in. That's where I've landed, at least. The years are
+just the container. What you poured into them is what counts.
+
+If you're hiring or growing a team, that's the lens I'd offer: stop counting years
+and start asking who reduces uncertainty for everyone else. It's served me well,
+but it's only my experience — test it against your own and keep what holds.

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -1,5 +1,5 @@
 ---
-title: "What actually makes an engineer senior"
+title: "Is a developer with ten years of experience senior?"
 slug: what-makes-an-engineer-senior
 date: 2026-06-26
 description: "Tenure isn't seniority, and seniority isn't management. After six
@@ -137,57 +137,58 @@ matters, **seniority does mean leadership in some form**. If your influence
 ends at the edge of your own keyboard, you're not senior yet, whatever the
 title says.
 
-## So what is it? Reducing uncertainty.
+## So what is it? Reducing uncertainty
 
-If I have to compress it into one idea, here it is. A senior engineer reduces
+If I have to compress it into one idea, here it is. Senior engineers reduce
 uncertainty for the people around them. Everything else is a symptom of that.
 Four things make it concrete.
 
-The first is technical culture. Knowing what not to do is usually worth more
-than knowing what to do. A senior has accumulated enough scars to recognize, on
-sight, the paths that end in tears. The clever abstraction that will rot. The
-"quick" migration that will eat a quarter. The architecture that looks fine on
-the whiteboard and becomes a hostage situation in production. It isn't theory.
-It's pattern matching, forged by having been burned, and it saves teams from
-running into walls that the senior already has the bruises from.
+**The first is technical culture.** Knowing what NOT to do is sometimes worth
+more than knowing what to do. A senior has accumulated enough scars to
+recognize, on sight, the paths that end in tears: clever abstractions that
+cause more harm than good, "quick" migrations that end up eating up a quarter,
+architectures which look fine on paper but suffer blatant scalability issues...
+The senior recognizes patterns and reduces uncertainty by being able to say
+"let's do this" or "let's not do this" with a good level of confidence.
 
-The second is communication. A senior can take a technical tradeoff and
-translate it into business impact a product manager can act on. They can explain
-an infrastructure risk in terms a CEO actually feels. They calibrate the level
-of detail to who's in the room, instead of either drowning people in jargon or
-talking down to them. This sounds obvious written down. It is genuinely rare and
-genuinely hard, and the people who can do it are worth their weight.
+**The second is communication.** A senior can take a technical tradeoff and
+translate it into business impact a product manager or a sales can act on. They
+can explain an infrastructure risk in terms a CEO actually feels. They
+calibrate the level of detail to who's in the room, instead of either drowning
+people in jargon or talking down to them. This sounds obvious written down but
+it's genuinely rare and hard.
 
-The third is vision beyond engineering, and in a startup or scale-up it's
-decisive. An engineer who understands churn, ARR, the acquisition funnel, and
-how much runway the burn rate leaves makes fundamentally different technical
-decisions than one who only sees code. They know when "good enough, shipped this
-week" beats "perfect, shipped next quarter," because they understand what the
-business is actually racing against. They prioritize differently. They anticipate
-the thing that's about to matter instead of polishing the thing that doesn't.
+**The third is vision beyond engineering**, which is especially relevant in a
+startup or scaleup. An engineer who understands churn, ARR, the acquisition
+funnel, and how much runway the burn rate leaves makes fundamentally different
+technical decisions than one who only sees code. They know when "good enough,
+shipped this week" beats "perfect, shipped next quarter," because they
+understand what the business is actually racing against. They prioritize
+differently and they anticipate the thing that's about to matter instead of
+polishing the thing that doesn't.
 
-The fourth is the multiplier effect, and it's the one that separates a genuinely
-good developer from a senior. A developer who only solves their own problems,
-even brilliantly and fast, is a good developer. Full stop. What makes someone
-senior is making the people around them better. Code review that teaches instead
-of just gatekeeping. Documentation that means the next person doesn't have to
-ask. Spending ten minutes to unblock a junior who's been stuck for two hours,
-instead of letting them grind so they "learn." Your individual output has a hard
-ceiling, set by the number of hours in your day. Your impact as a multiplier
-doesn't.
+**The fourth is the multiplier effect**. A developer who only solves their own
+problems, even brilliantly and fast, is a good developer, full stop. What makes
+someone senior is making the people around them better. Some examples: code
+review that teaches instead of just gatekeeping, documentation that means the
+next person doesn't have to ask, spending ten minutes to unblock a junior who's
+been stuck for two hours instead of letting them grind so they "learn". One's
+individual output has a hard ceiling, set by the number of hours they put out
+every day, but the impact as a multiplier doesn't.
 
 ## Back to the question
 
-So, is a developer with ten years of experience senior? In my experience you
-can't know from the sentence. Ten years tells you how long they've been employed,
-nothing more.
+So, is a developer with ten years of experience senior? In my experience, you
+can't know from the sentence. Ten years tells you how long they've been
+employed, nothing more.
 
 For me, being senior was never about time, titles, or lines of code. It's about
 what you did with the time. It's whether the people around you face less
-uncertainty because you're there, and whether they leave each interaction a little
-more capable than they came in. That's where I've landed, at least. The years are
-just the container. What you poured into them is what counts.
+uncertainty because you're there, and whether they leave each interaction a
+little more capable than they came in. That's where I've landed, at least. The
+years are just the container and it's what you poured into them that counts.
 
-If you're hiring or growing a team, that's the lens I'd offer: stop counting years
-and start asking who reduces uncertainty for everyone else. It's served me well,
-but it's only my experience — test it against your own and keep what holds.
+If you're hiring or growing a team, that's the lens I'd offer: stop counting
+years and start asking who reduces uncertainty for everyone else. It's served
+me well, but it's only my experience. Test it against your own and keep what
+holds! Good luck to you!

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -2,10 +2,10 @@
 title: "What actually makes an engineer senior"
 slug: what-makes-an-engineer-senior
 date: 2026-06-26
-description: "Tenure isn't seniority, and seniority isn't management. After five
-years co-founding and running engineering at a fintech, here's what I think
-seniority actually is: the ability to reduce uncertainty for the people around
-you."
+description: "Tenure isn't seniority, and seniority isn't management. After six
+years building an engineering team from one person to thirty at a fintech,
+here's what I think seniority actually is: the ability to reduce uncertainty for
+the people around you."
 ---
 
 Is a developer with ten years of experience senior?
@@ -15,11 +15,16 @@ must have seen a lot, learned a lot, earned the title. That instinct is exactly
 the problem. We treat seniority as something that accumulates on its own, like
 interest in a savings account, and it doesn't.
 
-I spent about five years co-founding a fintech startup and running its
-engineering as it grew into a scale-up. I hired seniors, I mislabeled people as
-seniors, I watched some "juniors" run circles around people with twice their
-tenure, and I made most of the classic mistakes myself. Along the way I changed
-my mind about what the word even means. Here's where I landed.
+This post is roughly a written version of a talk I gave in French a while back,
+which you can [watch here](https://www.youtube.com/watch?v=5I6Ozt30jI4&t=920s) if
+that's your language.
+
+I joined a fintech startup six years ago as a very early employee, and over the
+next stretch I built the engineering team from scratch, from one engineer to more
+than thirty. I hired seniors, I mislabeled people as seniors, I watched some
+"juniors" run circles around people with twice their tenure, and I made most of
+the classic mistakes myself. Along the way I changed my mind about what the word
+even means. Here's where I landed.
 
 ## Time in the chair is not the same as growth
 

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -76,10 +76,10 @@ on... each rung a tidy step above the last. But actual competence does not grow
 that way. You don't magically become "mid"
 after two years and "senior" after five.
 
-There's a saying that some people don't have ten years of experience; they have
-one year of experience, repeated ten times. The first year they learned the
-stack, shipped features, stopped breaking things. Years two through ten they
-did that same year again, a little faster, a little smoother, but not
+There's a saying that **some people don't have ten years of experience; they
+have one year of experience, repeated ten times**. The first year they learned
+the stack, shipped features, stopped breaking things. Years two through ten
+they did that same year again, a little faster, a little smoother, but not
 fundamentally harder or different.
 
 This is the plateau, and most developers reach some version of it. They ship,
@@ -99,17 +99,17 @@ feels easy is the day you've stopped getting better.
 ## Seniority is not management
 
 A very obvious and expensive mistake I've made myself is to promote great
-engineers to a management position. "She's been here five years, she's senior,
-let's give her a team." It's a great way to lose a strong engineer and
-manufacture a struggling manager in a single move...
+engineers to a management position. "He's been here five years, He's senior,
+let's give him a team." **It's a great way to lose a strong engineer and
+manufacture a struggling manager in a single move...**
 
-Management is not a promotion you earn by being good at engineering. It's a
-career change. It runs on a different set of skills that nobody acquires by
+**Management is not a promotion you earn by being good at engineering. It's a
+career change.** It runs on a different set of skills that nobody acquires by
 writing good code: giving feedback that lands, sitting in conflict without
 flinching, prioritizing other people's work, recruiting, absorbing pressure
 from above so your team can keep their heads down and a ton of other things.
-Some excellent engineers want none of that and / or are bad at it, and forcing
-it on them punishes everyone.
+**Some excellent engineers want none of that and / or are bad at it, and
+forcing it on them punishes everyone.**
 
 The healthier model has two tracks. There's the management track: tech lead,
 engineering manager, VP of Engineering. And there's the individual contributor
@@ -136,10 +136,12 @@ title says.
 
 ## So what is it? Reducing uncertainty
 
-If I have to compress it into one idea, here it is. Senior engineers reduce
-uncertainty for the people around them. Everything else is a symptom of that.
-Four things make it concrete, and all four assume real technical depth
-underneath: that's table stakes, not the differentiator.
+If I have to compress it into one idea, here it is. **Senior engineers reduce
+uncertainty for the people around them.** Everything else is a symptom of that.
+I've identified four main things that make it concrete. All four assume real
+technical depth underneath, but they lean just as hard on personality and soft
+skills: empathy, kindness, humility and the instinct to put the team before
+your own ego.
 
 **The first is technical culture.** Knowing what NOT to do is sometimes worth
 more than knowing what to do. A senior has accumulated enough scars to

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -1,0 +1,163 @@
+---
+title: "What actually makes an engineer senior"
+slug: what-makes-an-engineer-senior
+date: 2026-06-26
+description: "Tenure isn't seniority, and seniority isn't management. After five
+years co-founding and running engineering at a fintech, here's what I think
+seniority actually is: the ability to reduce uncertainty for the people around
+you."
+---
+
+Is a developer with ten years of experience senior?
+
+Most people answer yes without thinking about it. Ten years is a long time. They
+must have seen a lot, learned a lot, earned the title. That instinct is exactly
+the problem. We treat seniority as something that accumulates on its own, like
+interest in a savings account, and it doesn't.
+
+I spent about five years co-founding a fintech startup and running its
+engineering as it grew into a scale-up. I hired seniors, I mislabeled people as
+seniors, I watched some "juniors" run circles around people with twice their
+tenure, and I made most of the classic mistakes myself. Along the way I changed
+my mind about what the word even means. Here's where I landed.
+
+## Time in the chair is not the same as growth
+
+Someone who has been around longer does have more. More context, more scar
+tissue, more history with the codebase and the people and the decisions nobody
+remembers making. That's real, and it's valuable. But it is not the same thing
+as having gotten better at the craft.
+
+It helps to split what a person carries into two buckets. The first is
+contextual value: knowing why the billing service has that weird carve-out,
+remembering which client the retry logic was added for, knowing who to ask when
+the legacy import breaks. This is precious. It keeps the lights on. But it is
+bound to one environment. It evaporates the day they leave.
+
+The second is transferable competence: the part they take with them out the
+door. The judgment, the patterns, the ability to walk into a new system and a
+new team and be useful within weeks. When we say someone is senior, we usually
+mean we're impressed by their contextual value and we quietly assume the
+transferable competence is there too. Often it isn't.
+
+Picture two developers. One has eight years at a large company, working on a
+narrow slice of a big system, with well-defined specs handed down and a clear
+lane to stay in. The other has three years at an early-stage startup, making
+structural architecture decisions with incomplete information, getting paged at
+2am when production falls over, and scaling systems that were very much not built
+to be scaled. Who has more transferable competence?
+
+I'm not saying the answer is always the second one. The point is that the first
+one's eight years tell you almost nothing on their own. It's not about duration.
+It's about density of experience. Eight years of the same well-specified ticket
+is eight years of one thing. Three years of being thrown into the deep end
+repeatedly is something else entirely.
+
+## Skill doesn't grow in a straight line
+
+Company career ladders are roughly linear. Junior, mid, senior, lead, and so on,
+each rung a tidy step above the last. Actual competence does not grow that way.
+It moves in jumps and long flat stretches, and the ladder has no idea.
+
+There's a saying that gets repeated because it keeps being true. Some people
+don't have ten years of experience. They have one year of experience, repeated
+ten times. The first year they learned the stack, shipped features, stopped
+breaking things. Years two through ten they did that same year again, a little
+faster, a little smoother, but not fundamentally harder.
+
+This is the plateau, and most developers reach some version of it. They ship,
+they don't break prod, they know their tools. Life is fine up there. And here's
+the part people don't like to say out loud: usually there's no reason to leave.
+The work gets done, the paycheck arrives, nobody is demanding more. Not everyone
+is in love with this craft, and that is completely fine. Not every job has to be
+a calling. But comfort and growth are bad roommates. They don't share a space
+for long.
+
+What actually moves you off the plateau is the stuff that feels bad in the
+moment. Reading code you didn't write and wouldn't have written that way.
+Stepping into a problem domain you don't master and feeling like a beginner
+again. Taking the project where you're clearly the least qualified person in the
+room. Growth lives in that discomfort. The day everything at work feels easy is
+the day you've stopped getting better.
+
+## Seniority is not management
+
+Here is one of the most expensive mistakes a growing company makes, and I've
+both committed it and cleaned up after it. "She's been here five years, she's
+senior, let's give her a team." It's a great way to lose a strong engineer and
+manufacture a struggling manager in a single move.
+
+Management is not a promotion you earn by being good at engineering. It's a
+career change. It runs on a different set of skills that nobody acquires by
+writing good code: giving feedback that lands, sitting in conflict without
+flinching, prioritizing other people's work, recruiting, and absorbing pressure
+from above so your team can keep their heads down. Some excellent engineers want
+none of that, and forcing it on them punishes everyone.
+
+The healthier model has two tracks. There's the management track: tech lead,
+engineering manager, VP of Engineering. And there's the individual contributor
+track: senior engineer, staff engineer, principal engineer. Both are legitimate.
+Both go far, in title and in compensation. And both require leadership, which is
+the part people miss when they assume IC means "just codes, quietly."
+
+The difference is the kind of leadership. A manager has positional leadership.
+They have a team, they're responsible for people, the authority comes with the
+box on the org chart. A staff engineer has leadership of influence. They have
+authority over no one, and they still shape the technical direction, align teams
+that are drifting apart, and unblock situations that would otherwise stall for
+weeks. They lead because people choose to follow their judgment, not because
+they have to.
+
+So seniority does not mean management. But, and this is the nuance that matters,
+seniority does mean leadership in some form. If your influence ends at the edge
+of your own keyboard, you're not senior yet, whatever the title says.
+
+## So what is it? Reducing uncertainty.
+
+If I have to compress it into one idea, here it is. A senior engineer reduces
+uncertainty for the people around them. Everything else is a symptom of that.
+Four things make it concrete.
+
+The first is technical culture. Knowing what not to do is usually worth more
+than knowing what to do. A senior has accumulated enough scars to recognize, on
+sight, the paths that end in tears. The clever abstraction that will rot. The
+"quick" migration that will eat a quarter. The architecture that looks fine on
+the whiteboard and becomes a hostage situation in production. It isn't theory.
+It's pattern matching, forged by having been burned, and it saves teams from
+running into walls that the senior already has the bruises from.
+
+The second is communication. A senior can take a technical tradeoff and
+translate it into business impact a product manager can act on. They can explain
+an infrastructure risk in terms a CEO actually feels. They calibrate the level
+of detail to who's in the room, instead of either drowning people in jargon or
+talking down to them. This sounds obvious written down. It is genuinely rare and
+genuinely hard, and the people who can do it are worth their weight.
+
+The third is vision beyond engineering, and in a startup or scale-up it's
+decisive. An engineer who understands churn, ARR, the acquisition funnel, and
+how much runway the burn rate leaves makes fundamentally different technical
+decisions than one who only sees code. They know when "good enough, shipped this
+week" beats "perfect, shipped next quarter," because they understand what the
+business is actually racing against. They prioritize differently. They anticipate
+the thing that's about to matter instead of polishing the thing that doesn't.
+
+The fourth is the multiplier effect, and it's the one that separates a genuinely
+good developer from a senior. A developer who only solves their own problems,
+even brilliantly and fast, is a good developer. Full stop. What makes someone
+senior is making the people around them better. Code review that teaches instead
+of just gatekeeping. Documentation that means the next person doesn't have to
+ask. Spending ten minutes to unblock a junior who's been stuck for two hours,
+instead of letting them grind so they "learn." Your individual output has a hard
+ceiling, set by the number of hours in your day. Your impact as a multiplier
+doesn't.
+
+## Back to the question
+
+So, is a developer with ten years of experience senior? You can't know from the
+sentence. Ten years tells you how long they've been employed, nothing more.
+
+Being senior was never about time, titles, or lines of code. It's about what you
+did with the time. It's whether the people around you face less uncertainty
+because you're there, and whether they leave each interaction a little more
+capable than they came in. That's the whole thing. The years are just the
+container. What you poured into them is what counts.

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -16,8 +16,6 @@ earned the title. That instinct is exactly the problem. We tend to treat
 seniority as something that accumulates on its own, like interest in a savings
 account... But I don't think it does!
 
----
-
 This post is roughly a written version of a talk I gave in French a while back,
 which you can [watch here](https://www.youtube.com/watch?v=5I6Ozt30jI4&t=920s) if
 that's your language.

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -8,12 +8,6 @@ what I've come to believe seniority is: the ability to reduce uncertainty for th
 people around you."
 ---
 
-This post is roughly a written version of a talk I gave in French a while back,
-which you can [watch here](https://www.youtube.com/watch?v=5I6Ozt30jI4&t=920s) if
-that's your language.
-
----
-
 Is a developer with ten years of experience senior?
 
 I think most people would answer "yes" without really thinking about it. Ten
@@ -21,6 +15,14 @@ years is a long time after all. They must have seen a lot, learned a lot,
 earned the title. That instinct is exactly the problem. We tend to treat
 seniority as something that accumulates on its own, like interest in a savings
 account... But I don't think it does!
+
+---
+
+This post is roughly a written version of a talk I gave in French a while back,
+which you can [watch here](https://www.youtube.com/watch?v=5I6Ozt30jI4&t=920s) if
+that's your language.
+
+---
 
 I joined a fintech startup as CTO six years ago, when the company was only four
 people (including me!). I built the engineering team from scratch, from one
@@ -59,24 +61,21 @@ experience, it's not always the case.
 Picture two developers... One has eight years at a large company, working on a
 narrow slice of a big system, with well-defined specs handed down and a clear
 lane to stay in. The other has three years at an early-stage startup, making
-structural architecture decisions with incomplete information, getting ping'd
-late when production falls over, and scaling systems that were very much not
-built to be scaled. Who has more transferable competence between these two
-guys?
+structural architecture decisions with incomplete information, getting paged
+at 2am when production falls over, and scaling systems that were very much not
+built to be scaled. Who has more transferable competence?
 
 I'm not saying the answer is always the second one. **The point is that the first
 one's eight years tell you almost nothing on their own.** It's not about duration,
-it's about density of experience. Eight years of the same well-specified ticket
+it's about **density of experience**. Eight years of the same well-specified ticket
 is eight years of one thing. Three years of being thrown into the deep end
 repeatedly is something else entirely.
 
 ## Skill doesn't grow in a straight line
 
 Company career ladders are roughly linear: junior, mid, senior, lead, and so
-on... each run a tidy step above the last. That's especially true for early
-startups who want to focus on building stuff and tend to delay the moment they
-start to take HR and personal growth matters seriously. But the point is that
-actual competence does not grow that way. You don't magically become "mid"
+on... each rung a tidy step above the last. But actual competence does not grow
+that way. You don't magically become "mid"
 after two years and "senior" after five.
 
 There's a saying that some people don't have ten years of experience; they have
@@ -96,14 +95,14 @@ What actually moves you off the plateau is the stuff that feels bad in the
 moment: reading code you didn't write and wouldn't have written that way,
 stepping into a problem domain you don't master and feeling like a beginner
 again, taking the project where you're clearly the least qualified person in
-the room, etc. Growth lives in that discomfort and growth will increase your
-seniority level.
+the room, etc. Growth lives in that discomfort. The day everything at work
+feels easy is the day you've stopped getting better.
 
 ## Seniority is not management
 
-A very obvious and expensive mistake I've done myself is to promote great
-engineers to management position. "He's been here five years, he's senior,
-let's give him a team." It's a great way to lose a strong engineer and
+A very obvious and expensive mistake I've made myself is to promote great
+engineers to a management position. "She's been here five years, she's senior,
+let's give her a team." It's a great way to lose a strong engineer and
 manufacture a struggling manager in a single move...
 
 Management is not a promotion you earn by being good at engineering. It's a
@@ -111,7 +110,7 @@ career change. It runs on a different set of skills that nobody acquires by
 writing good code: giving feedback that lands, sitting in conflict without
 flinching, prioritizing other people's work, recruiting, absorbing pressure
 from above so your team can keep their heads down and a ton of other things.
-Some excellent engineers want none of that and / or are bad a it, and forcing
+Some excellent engineers want none of that and / or are bad at it, and forcing
 it on them punishes everyone.
 
 The healthier model has two tracks. There's the management track: tech lead,
@@ -141,7 +140,8 @@ title says.
 
 If I have to compress it into one idea, here it is. Senior engineers reduce
 uncertainty for the people around them. Everything else is a symptom of that.
-Four things make it concrete.
+Four things make it concrete, and all four assume real technical depth
+underneath: that's table stakes, not the differentiator.
 
 **The first is technical culture.** Knowing what NOT to do is sometimes worth
 more than knowing what to do. A senior has accumulated enough scars to
@@ -152,7 +152,7 @@ The senior recognizes patterns and reduces uncertainty by being able to say
 "let's do this" or "let's not do this" with a good level of confidence.
 
 **The second is communication.** A senior can take a technical tradeoff and
-translate it into business impact a product manager or a sales can act on. They
+translate it into business impact a product manager or salesperson can act on. They
 can explain an infrastructure risk in terms a CEO actually feels. They
 calibrate the level of detail to who's in the room, instead of either drowning
 people in jargon or talking down to them. This sounds obvious written down but
@@ -168,13 +168,15 @@ differently and they anticipate the thing that's about to matter instead of
 polishing the thing that doesn't.
 
 **The fourth is the multiplier effect**. A developer who only solves their own
-problems, even brilliantly and fast, is a good developer, full stop. What makes
-someone senior is making the people around them better. Some examples: code
-review that teaches instead of just gatekeeping, documentation that means the
-next person doesn't have to ask, spending ten minutes to unblock a junior who's
-been stuck for two hours instead of letting them grind so they "learn". One's
-individual output has a hard ceiling, set by the number of hours they put out
-every day, but the impact as a multiplier doesn't.
+problems, even brilliantly and fast, is a great developer. What tips them into
+senior is making the people around them better, whether directly or through the
+systems they leave behind. Some examples: code review that teaches instead of
+just gatekeeping, documentation that means the next person doesn't have to ask,
+an architecture clean enough that nobody has to ask how it works, spending ten
+minutes to unblock a junior who's been stuck for two hours instead of letting
+them grind so they "learn". Your
+individual output has a hard ceiling, set by the hours in your day. Your impact
+as a multiplier doesn't.
 
 ## Back to the question
 


### PR DESCRIPTION
## What

Adds a new blog post, `src/content/posts/what-makes-an-engineer-senior.md`, a first-person essay on engineering seniority written from the perspective of a fintech co-founder/CTO.

**Title:** What actually makes an engineer senior
**Subtitle / description:** Tenure isn't seniority, and seniority isn't management. After five years co-founding and running engineering at a fintech, here's what I think seniority actually is: the ability to reduce uncertainty for the people around you.

## Structure

- **Hook:** is a dev with 10 years of experience senior?
- **Confusion `#1`:** tenure ≠ seniority (contextual value vs. transferable competence, density of experience)
- **Non-linear growth:** the plateau, "1 year repeated 10 times," discomfort as the engine of growth
- **Confusion `#2`:** seniority ≠ management (management vs. IC tracks, positional vs. influence leadership)
- **Core thesis:** seniority = reducing uncertainty, developed through four pillars (technical culture, communication, vision beyond engineering, multiplier effect)
- **Punchy close** that loops back to the opening question

## Notes

- ~1,520 words, first person, conversational tone, no em dashes (per the brief)
- Frontmatter matches the existing post schema (title/slug/date/description)
- `npm run build` passes; post renders at `/what-makes-an-engineer-senior/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASWm3fZNmyy5nfDmJBDC4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASWm3fZNmyy5nfDmJBDC4Y)_
