### PR TITLE
Fix spelling, grammar, and agreement errors across all content

### DIFF
--- a/src/content/pages/2019-forensics-00-student.md
+++ b/src/content/pages/2019-forensics-00-student.md
@@ -29,10 +29,10 @@ en servir pour prouver telle ou telle chose.
 En forensique, on :
 
 * Analyse des formats de fichiers inconnus
-* Ecrit des scripts et programme pour automatiser l'analyse
+* Écrit des scripts et programmes pour automatiser l'analyse
 * Analyse des dumps de mémoire vive
 * Met en relation des évènements pour élaborer un scénario (d'attaque par exemple)
-* Surement d'autres trucs
+* Sûrement d'autres trucs
 
 Le forensique n'a pas vraiment été touché par le 'tout en Python' ou le 'tout
 en Javascript'. C'est un domaine où on manipule des offsets et où on aime bien
@@ -43,7 +43,7 @@ Un outil de forensique très populaire
 est [Volatility](https://www.volatilityfoundation.org/). C'est un framework
 Python pour l'analyse de dump RAM. Il marche super bien mais on galère à
 retenir les commandes donc je vous donne tout de suite une cheatsheet avec
-tout ce qui faut : [cliquez ici](https://downloads.volatilityfoundation.org/releases/2.4/CheatSheet_v2.4.pdf).
+tout ce qu'il faut : [cliquez ici](https://downloads.volatilityfoundation.org/releases/2.4/CheatSheet_v2.4.pdf).
 
 La plupart des épreuves de forensique que vous trouvez sur internet sont bien
 entendu simulées. Il est assez rare de tomber sur le dernier format de fichier
@@ -53,7 +53,7 @@ affaire criminelle.
 
 ## Exercice 00
 
-Faison un peu d'analyse mémoire. C'est amusant, ça ne demande pas beaucoup
+Faisons un peu d'analyse mémoire. C'est amusant, ça ne demande pas beaucoup
 d'effort, et ça revient souvent en CTF ! Pour tous les exercices suivants, vous
 allez travailler sur [le fichier `dump_ram` fourni](https://cdn.geographer.fr/forensics_00_dump_ram.zip).
 
@@ -63,7 +63,7 @@ a été infecté par un logiciel malveillant (le boulet...). Nous allons
 mener l'enquête et essayer de comprendre ce qui se passe dans cette VM !
 
 **IMPORTANT ! Ce fichier est tiré du OtterCTF et il est la propriété
-de Asaf Eitani ! Mais je le trouvais cool alors je l'ai emprunté...**
+d'Asaf Eitani ! Mais je le trouvais cool alors je l'ai emprunté...**
 
 Installez Volatility puis trouvez le profil adapté pour ce dump.
 
@@ -81,8 +81,8 @@ l'ordinateur ainsi que le mot de passe de Rick.
 
 ## Exercice 02
 
-Nous en savons désormais un peu plus. Un collègue souhaiterai jeter un oeil
-au traffic réseau de cette machine virtuelle au moment de l'incident...
+Nous en savons désormais un peu plus. Un collègue souhaiterait jeter un œil
+au trafic réseau de cette machine virtuelle au moment de l'incident...
 
 Quelle est l'adresse IP de la machine sur le réseau local ?
 
@@ -92,12 +92,12 @@ Quelle est l'adresse IP de la machine sur le réseau local ?
 Ce n'est pas certain, mais on peut supposer que le malware qui a
 infecté la machine communique avec un serveur distant.
 
-Si tel est le cas, quel est l'IP de ce serveur distant ?
+Si tel est le cas, quelle est l'IP de ce serveur distant ?
 
 
 ## Exercice 04
 
-Jetons plutôt un oeil à la liste des processus en cours d'exécution.
+Jetons plutôt un œil à la liste des processus en cours d'exécution.
 
 Un de ces processus devrait attirer votre attention, lequel ? Un indice :
 soyez attentif aux liens de parenté des processus. Il est rare que
@@ -111,7 +111,7 @@ d'exécution. En effet, en RAM, le contenu chiffré est souvent en clair... :p
 
 ## Exercice 05
 
-Commencez par obtenir des informations sur le logiciel malveillant. A quel
+Commencez par obtenir des informations sur le logiciel malveillant. À quelle
 famille appartient-il ? Est-il déjà répertorié ?
 
 
@@ -128,7 +128,7 @@ espion !
 ## Exercice 07
 
 Nous aimerions comprendre comment ce malware est arrivé là... Je me souviens
-avoir vu du client Bittorent dans le liste des processus en cours. Le collègue
+avoir vu un client BitTorrent dans la liste des processus en cours. Le collègue
 qui a regardé les logs réseau confirme ceci (merci à lui !). Rick devait encore
 être en train de récupérer des séries pour glander au bureau... Essayez d'en
 savoir plus !
@@ -147,7 +147,7 @@ ce boulet...
 
 Retrouvez la clé de chiffrement utilisée pour prendre les fichiers de Rick
 en otage. Un indice : il me semble que `.NET` fait des choses étranges
-avec les chaines de caractères.
+avec les chaînes de caractères.
 
 
 ## Exercice 09
@@ -159,11 +159,11 @@ Enfin, déchiffrez les fichiers de Rick !
 
 ## Exercice 10
 
-Je suis toujours étonné de tout ce qu'on faire avec un dump RAM. Sans même
+Je suis toujours étonné de tout ce qu'on peut faire avec un dump RAM. Sans même
 toucher à la machine virtuelle, nous avons pu reconstruire tout le scénario
 de l'infection, obtenir la preuve que Rick est un boulet et trouver un moyen
 de déchiffrer ses fichiers.
 
-Pour finir, faites le point sur la journée, dites nous ce que vous avez aimé,
+Pour finir, faites le point sur la journée, dites-nous ce que vous avez aimé,
 pas aimé, tous vos retours, ce que vous voulez... Et envoyez un petit
 mail à <lucas.santoni@epitech.eu>.

--- a/src/content/pages/2019-forensics-00-teacher.md
+++ b/src/content/pages/2019-forensics-00-teacher.md
@@ -9,16 +9,16 @@ sonder un peu le niveau de la salle.
 
 **Les étudiants doivent avoir un Linux ou un macOS sous la main (si y'en
 a qui se sentent de faire du Volatility sous Windows pourquoi pas mais
-je m'y risquerai pas).**
+je m'y risquerais pas).**
 
 **Les étudiants doivent avoir une machine virtuelle sous Windows disponible.
-Les machines physiques sont à proscrire, il va y avoir de reverse de logiciel
+Les machines physiques sont à proscrire, il va y avoir du reverse de logiciel
 malveillant.**
 
 
 ## Exercice 00
 
-Volatility peut être installé via quelques packet managers (Aur, Brew)
+Volatility peut être installé via quelques package managers (Aur, Brew)
 mais une solution moins aléatoire est de récupérer toute l'archive du projet
 et de lancer le `vol.py` manuellement.
 
@@ -33,7 +33,7 @@ Pour trouver le profil, on utilise la commande `imageinfo` qui nous donne :
 * Win2008R2SP1x64
 * Win7SP1x64\_23418
 
-Le premier fera l'affaire. C'est le moment moment pour expliquer la structure
+Le premier fera l'affaire. C'est le moment pour expliquer la structure
 d'une commande Volatility. On met toujours le fichier sur lequel on travaille
 et le profil. Puis on ajoute un verbe qui prend éventuellement des arguments.
 
@@ -55,7 +55,7 @@ Virtual            Physical           Name
 [...]
 ```
 
-On peut par la suite aller chercher le clé qui nous intéresse dans cette *hive* avec
+On peut par la suite aller chercher la clé qui nous intéresse dans cette *hive* avec
 la commande `printkey` :
 
 ```
@@ -110,7 +110,7 @@ dépendances Python n'est alors pas le bon.**
 **En cas de problème de nom sur `construct`, installer la version
 `construct==2.5.5-reupload` du module.**
 
-Le plugin `mimikatz` (fondé sur les recherches ayant permi de réaliser le
+Le plugin `mimikatz` (fondé sur les recherches ayant permis de réaliser le
 projet du même nom qui vaut le coup d'être introduit) permet d'aller pêcher le
 mot de passe en clair :
 
@@ -192,7 +192,7 @@ Writing vmware-tray.ex [  3720] to 3720.dmp
 Il faut bien insister sur le fait que l'empreinte mémoire du processus est
 tout aussi intéressante que le processus en lui même. On peut récupérer
 très facilement des clés en clair, des adresses de paiement, des noms de
-domaine, des URL de C&C, ect.
+domaine, des URL de C&C, etc.
 
 
 ## Exercice 05
@@ -215,14 +215,14 @@ Loader-Private
 C:\Users\Tyler\Desktop\hidden-tear-master\hidden-tear\hidden-tear\obj\Debug\VapeHacksLoader.pdb
 ```
 
-On trigger sur `VapeHacksLoader`. Une recherche Google nous ammène sur $
-ucyLocker. Je connais pas le malware mais on dirait du commercial, surement un
+On trigger sur `VapeHacksLoader`. Une recherche Google nous amène sur
+$ucyLocker. Je connais pas le malware mais on dirait du commercial, sûrement un
 ransomware clé en main.
 
-La dernière chaîne affichée passe par ce qui semble être un dépot versionné (en
+La dernière chaîne affichée passe par ce qui semble être un dépôt versionné (en
 raison du suffixe `-master`). Une recherche Google sur `hidden-tear-master`
-nous renvoie sur [ce dépot GitHub](https://github.com/goliate/hidden-tear).
-C'est un ransomware libre avec lequel on peut jouer un peu. C'est surement ça
+nous renvoie sur [ce dépôt GitHub](https://github.com/goliate/hidden-tear).
+C'est un ransomware libre avec lequel on peut jouer un peu. C'est sûrement ça
 qui a été utilisé pour construire l'épreuve.
 
 
@@ -266,9 +266,9 @@ tant mieux. Pour ceux qui ne le savent pas encore, on peut leur en parler
 maintenant mais je mets un indice plus tard lié à ça quand ça devient
 indispensable.
 
-L'expression régulière qu'on passe à `ag` vient de [cette rêgle Yara](https://github.com/JusticeRage/Manalyze/blob/master/bin/yara_rules/bitcoin.yara).
+L'expression régulière qu'on passe à `ag` vient de [cette règle Yara](https://github.com/JusticeRage/Manalyze/blob/master/bin/yara_rules/bitcoin.yara).
 
-On peut en profiter pour faire une petite démo Yara ! On part de la rêgle de
+On peut en profiter pour faire une petite démo Yara ! On part de la règle de
 Didier Stevens, on se rajoute le mot clé `wide` pour indiquer que les
 caractères sont sur deux octets (toujours à cause de l'UTF-16) et ça passe :
 
@@ -296,7 +296,7 @@ Owner: Process vmware-tray.ex Pid 3720
 0x00ec52c6  50 00 72 00 6f 00 70 00 65 00 72 00 74 00 69 00   P.r.o.p.e.r.t.i.
 ```
 
-La rêgle :
+La règle :
 
 ```
 rule BitcoinAddress {
@@ -316,19 +316,19 @@ rule BitcoinAddress {
 Le malware s'est installé en trois étapes :
 
 * Un fichier torrent a été téléchargé depuis Chrome
-* Rick a ouvert le torrent et récupéré son soit disant épisode de Rick &
+* Rick a ouvert le torrent et récupéré son soi-disant épisode de Rick &
   Morty
 * Rick a double-cliqué sur l'exécutable qui se faisait passer pour une vidéo,
   cet exécutable drop le malware qui a chiffré son disque
 
 En réalité, je n'ai pas vérifié si `Rick & Morty` était vraiment un dropper
-mais à vu de nez...
+mais à vue de nez...
 
-A partir du moment où l'étudiant met tout ça dans le bon ordre, c'est correct.
+À partir du moment où l'étudiant met tout ça dans le bon ordre, c'est correct.
 
 Autrement, les flags attendus sont obtenus ainsi...
 
-On sait que du Bittorent tourne donc il doit bien y avoir du fichier `.torrent`
+On sait que du BitTorrent tourne donc il doit bien y avoir du fichier `.torrent`
 quelque part sur la machine :
 
 ```
@@ -340,7 +340,7 @@ Volatility Foundation Volatility Framework 2.6
 0x000000007dcbf6f0      2      0 RW-rwd \Device\HarddiskVolume1\Users\Rick\AppData\Roaming\BitTorrent\Rick And Morty season 1 download.exe.1.torrent
 ```
 
-**A partir de là, on va commencer à abuser de `grep`. Même si ça peut sembler
+**À partir de là, on va commencer à abuser de `grep`. Même si ça peut sembler
 assez bourrin, ça permet de plier rapidement pas mal d'épreuves en CTF...
 Il peut être intéressant de présenter quelques outils CLI améliorés tels
 que :**
@@ -421,11 +421,11 @@ end
 ```
 
 Ce script peut être proposé aux étudiants. Il prend un truc comme 40 secondes
-à être codé en live et il montre le temps qu'on peut gagner en maitrisant
+à être codé en live et il montre le temps qu'on peut gagner en maîtrisant
 un peu son shell. Le trick du `&` est sympa aussi : on lance en fait le
 processus en arrière plan. De ce fait, on peut tout de suite démarrer un
 nouveau processus et paralléliser le travail. Les processus en arrière plan
-peuvent être surveillés avec la commande `fg`.
+peuvent être listés avec la commande `jobs`.
 
 Tout roule :
 
@@ -488,7 +488,7 @@ tbl_1533411035475_7.0.9.40728_2033115181
 [...]
 ```
 
-Mémotechnique à filer aux étudiants : `-B`/`-A` pour **B**efore et **A**fter.
+Mnémotechnique à filer aux étudiants : `-B`/`-A` pour **B**efore et **A**fter.
 
 On repère `Hum@n_I5_Th3_Weak3s7_Link_In_Th3_Ch@inYear`.
 
@@ -500,7 +500,7 @@ baladant un peu on tombe sur une routine intéressante :
 
 ![dnSpy Routine](/assets/forensics-00/dnspy_routine.png)
 
-La fonction `CreatePassword` génère une chaine de caractère aléatoire.
+La fonction `CreatePassword` génère une chaîne de caractères aléatoire.
 C'est le mot de passe que l'on recherche. Le mot de passe généré est ensuite
 passé à la fonction `SendPassword` qui a le corps suivant :
 
@@ -508,7 +508,7 @@ passé à la fonction `SendPassword` qui a le corps suivant :
 
 On peut raisonnablement espérer que la valeur de retour de cette fonction
 se trouve dans notre dump de la mémoire du processus. On peut `grep` assez
-facilement étant donné que l'on connait le nom de la machine ainsi que le
+facilement étant donné que l'on connaît le nom de la machine ainsi que le
 nom de l'utilisateur courant :
 
 ```
@@ -539,7 +539,7 @@ vol.py -f OtterCTF.vmem --profile=Win7SP1x64 filescan | ag "desktop"
 [...]
 ```
 
-Le nom `Flag.txt` est assez évoquateur... On se le dump :
+Le nom `Flag.txt` est assez évocateur... On se le dump :
 
 ```
 vol.py -f OtterCTF.vmem --profile=Win7SP1x64 dumpfiles -Q 0x000000007e410890 -D .
@@ -549,7 +549,7 @@ DataSectionObject 0x7e410890   None   \Device\HarddiskVolume1\Users\Rick\Desktop
 ```
 
 En regardant un peu le code de `hidden-tear`, on voit que c'est de l'AES. Il
-y a un programme de déchiffrement dans le dépot donc on se le récupère.
+y a un programme de déchiffrement dans le dépôt donc on se le récupère.
 La fonction intéressante est `AES_Decrypt` :
 
 ```cs
@@ -598,13 +598,13 @@ déchiffrement ne passe que sur les fichiers avec cette extension :
 ![Extension .locked obligatoire !](/assets/forensics-00/locked_only.png)
 
 On peut valider dans dnSpy que l'utilisateur du ransomware n'a pas
-modifié de paramêtre lors du chiffrement :
+modifié de paramètre lors du chiffrement :
 
-![Foncton de chiffrement](/assets/forensics-00/encrypt.png)
+![Fonction de chiffrement](/assets/forensics-00/encrypt.png)
 
-On peut comparer avec le dépot du projet, c'est bien la fonction
+On peut comparer avec le dépôt du projet, c'est bien la fonction
 originale. Il faut insister sur ces vérifications qui peuvent donner
-l'impression qu'on est complêtement à côté de la solution alors qu'on
+l'impression qu'on est complètement à côté de la solution alors qu'on
 a juste oublié de récupérer une valeur de salt différente, par exemple.
 
 Tout roule :
@@ -616,4 +616,4 @@ Et on obtient le flag final : `CTF{Im_Th@_B3S7_RicK_0f_Th3m_4ll}`.
 
 ## Exercice 10
 
-Il faut insister pour les étudiants nous fassent un petit retour...
+Il faut insister pour que les étudiants nous fassent un petit retour...

--- a/src/content/pages/2019-reverse-00-student.md
+++ b/src/content/pages/2019-reverse-00-student.md
@@ -4,7 +4,7 @@ slug: 2019-reverse-00-student
 ---
 
 Cette journée est une introduction au *reverse*, ou **rétro-ingénierie**
-(voire même ingénierie à reculon si vous êtes ce genre de personne) en
+(voire même ingénierie à reculons si vous êtes ce genre de personne) en
 français. J'utiliserai le terme anglais reverse tout au long de ce document,
 on va pas se prendre la tête.
 
@@ -33,14 +33,14 @@ ce que ça donne une fois compilé
 * simplement se faire plaisir, c'est cool le reverse, ça fait travailler le
 cerveau et ça élimine les gueules de bois
 
-Il n'y a pas vraiment de langage de programmation à connaitre... Le Python
+Il n'y a pas vraiment de langage de programmation à connaître... Le Python
 peut aider pour du scripting et le C rend service quand on veut faire des
 tests un peu plus bas niveau mais ça peut toujours se remplacer. D'une manière
-générale, connaitre le langage de programmation qui a servi à produire le
+générale, connaître le langage de programmation qui a servi à produire le
 binaire que l'on veut reverse est une très bonne chose.
 
 Quand on fait du reverse, on se retrouve face à un listing assembleur. On peut
-donc se dire que c'est une bonne idée de connaitre ce langage. J'aime pas
+donc se dire que c'est une bonne idée de connaître ce langage. J'aime pas
 vraiment considérer l'assembleur du reverse comme un langage de programmation.
 Le listing que l'on voit est simplement une représentation plus humaine du
 programme compilé. Il n'y a aucune différence entre la suite d'octets que l'on
@@ -58,10 +58,10 @@ et très fastidieux mais ça permet d'avancer au début et au bout de quelques
 fois, on peut tout faire de tête.
 * Mémorisez et recherchez les "patterns" de
 [control flow](https://en.wikipedia.org/wiki/Control_flow) : conditions,
-boucles, sauts, appels de fonction... Ce sont à ces endroits là qu'il y a de
+boucles, sauts, appels de fonction... C'est à ces endroits-là qu'il y a de
 l'action !
 
-**Attention : Nous attendons des réponses complêtes et exhaustives de votre
+**Attention : Nous attendons des réponses complètes et exhaustives de votre
 part. Que vous trouviez le mot de passe d'un exercice ne nous intéresse
 en réalité pas vraiment... Ce sont les questions qui attireront votre attention
 sur les notions importantes et qui vous permettront de progresser.**
@@ -76,14 +76,14 @@ Installez GDB puis installez [PEDA](https://github.com/longld/peda).
 
 Au passage, un peu de vocabulaire :
 
-* un débogueur est un logiciel qui vient se mettre au dessus d'un autre binaire
+* un débogueur est un logiciel qui vient se mettre au-dessus d'un autre binaire
 afin de monitorer son exécution et permettre de mettre le programme en pause,
-placer des points d'arrêts, inspecter le contenu des registres ou de la
-mémoire... (exemple: GDB)
+placer des points d'arrêt, inspecter le contenu des registres ou de la
+mémoire... (exemple : GDB)
 * un désassembleur est un logiciel qui, à partir d'un binaire compilé, vient
-nous générer un listing assembleur (exemple: `objdump -D`)
-* un décompilateur est un logiciel qui, à partir d'une binaire compilé, vient
-nous générer un pseudo-code, souvent proche du C (exemple: Hex-Rays Decompiler,
+nous générer un listing assembleur (exemple : `objdump -D`)
+* un décompilateur est un logiciel qui, à partir d'un binaire compilé, vient
+nous générer un pseudo-code, souvent proche du C (exemple : Hex-Rays Decompiler,
 parfois surnommé *F5 dans IDA*)
 
 GDB a beaucoup de commandes, gardez
@@ -111,7 +111,7 @@ Ce binaire demande un mot de passe... On appelle ça un *crackme* ou un
 *reverseme*. C'est un logiciel qui a été développé dans le seul but de produire
 un exercice de reverse.
 
-Quel est le mot de passe demandé ? Avez vous vraiment besoin de GDB pour le
+Quel est le mot de passe demandé ? Avez-vous vraiment besoin de GDB pour le
 trouver ?
 
 Indice : I wanna be tracer !
@@ -163,7 +163,7 @@ symboles, nous avons par exemple :
 * des noms de variables
 * des bouts du code source original
 
-Sans les symboles, le débogage est plus compliqué. Surtout, le "démarage" est
+Sans les symboles, le débogage est plus compliqué. Surtout, le "démarrage" est
 plus compliqué car on ne peut pas lâcher un `disas main` et commencer à se
 repérer à partir de là.
 
@@ -171,10 +171,10 @@ Utilisez `readelf` ou GDB pour récupérer le point d'entrée du programme.
 Existe-t-il un lien entre le point d'entrée du programme et l'adresse de la
 fonction main ?
 
-Répondez ensuite aux questions suivante :
+Répondez ensuite aux questions suivantes :
 
 * donnez l'adresse de la fonction `main`
-* trouvez l'adresse à laquelle est stockée le flag
+* trouvez l'adresse à laquelle est stocké le flag
 * trouvez le mot de passe demandé
 
 
@@ -182,7 +182,7 @@ Répondez ensuite aux questions suivante :
 
 Téléchargez le fichier [bin06](/assets/reverse-00/ex06/bin06).
 
-Ce binaire a l'air différent... Peut être que la commande `file` pourrait nous
+Ce binaire a l'air différent... Peut-être que la commande `file` pourrait nous
 donner plus d'informations ?
 
 Trouvez le mot de passe demandé.
@@ -193,7 +193,7 @@ très bonne chose !
 
 ## Exercice 07
 
-*Cet exercice est une création de **Oursin**, merci à lui !*.
+*Cet exercice est une création de **Oursin**, merci à lui !*
 
 Téléchargez le fichier [bin07](/assets/reverse-00/ex07/bin07).
 
@@ -216,7 +216,7 @@ Téléchargez le fichier [bin08](/assets/reverse-00/ex08/siglol).
 
 Trouvez le mot de passe demandé.
 
-Cet exercice est plus dur que les autres. Vous n'aurez surement pas le temps de
+Cet exercice est plus dur que les autres. Vous n'aurez sûrement pas le temps de
 le faire pendant la journée. N'hésitez pas à y revenir plus tard et poser des
 questions à <sylvain.lefevre@epitech.eu> !
 

--- a/src/content/pages/2019-reverse-00-teacher.md
+++ b/src/content/pages/2019-reverse-00-teacher.md
@@ -3,7 +3,7 @@ title: Une journée de rétro-ingénierie (00)
 slug: 2019-reverse-00-teacher
 ---
 
-Si on est sur un public qui a déjà fait un de reverse ou qui, du moins,
+Si on est sur un public qui a déjà fait un peu de reverse ou qui, du moins,
 connaît les enjeux du bas niveau et n'a pas peur d'un listing assembleur,
 on peut se passer d'une intro et aller tout de suite à la démo.
 
@@ -18,7 +18,7 @@ Il faut aussi insister sur le fait que l'assembleur peut s'apprendre sur le tas
 mais qu'il est important de poser des questions aux assistants ou faire des
 recherches Google. Pour ceux qui veulent en savoir plus, j'aime bien
 [Le langage assembleur](https://www.editions-eni.fr/livre/le-langage-assembleur-maitrisez-le-code-des-processeurs-de-la-famille-x86-9782746065086)
-de Olivier CAUET. Attention, peut être un peu cher pour ce que c'est mais c'est
+d'Olivier CAUET. Attention, peut-être un peu cher pour ce que c'est mais c'est
 cool de l'avoir dans la collection.
 
 Parmi les exercices, il y a des binaires compilés avec `clang` pour le 32
@@ -43,7 +43,7 @@ pas bon.**
 ## Exercice 00
 
 On installe GDB, peu importe la distribution Linux il devrait être dans les
-dépots. Pour Peda, on suit simplement le [GitHub](https://github.com/longld/peda).
+dépôts. Pour Peda, on suit simplement le [GitHub](https://github.com/longld/peda).
 
 Une fois GDB installé, on part sur une petite démonstration. On peut faire
 la démo sur l'exercice 01. Il faut leur montrer :
@@ -127,7 +127,7 @@ Prologue :
 0x080484f4 <+4>:	sub    esp,0x34
 ```
 
-On a donc `0x34`, soit 52 octets réservés. 
+On a donc `0x34`, soit 52 octets réservés.
 
 La boucle :
 
@@ -172,7 +172,7 @@ gdb-peda$ x/s 0x0804a008
 0x804a008:	"avec_effet_de_serre"
 ```
 
-On a `EBP-0x14` qui vaut `0xffffd714`. A cette adresse se trouve le pointeur
+On a `EBP-0x14` qui vaut `0xffffd714`. À cette adresse se trouve le pointeur
 vers notre flag (avant parcours ici) : `0x0804a008`.
 
 Ce pointeur est par exemple déréférencé en `main+179` :
@@ -233,11 +233,11 @@ comme une chaîne de caractères mais comme un `uint64_t` que nous traitons
 en deux `uint32_t`.
 
 La fonction `soap` prend deux valeurs non signées sur 4 octets en paramètre.
-Ces deux valeurs sont parcourues octets par octets. Les octets sont XORés deux
+Ces deux valeurs sont parcourues octet par octet. Les octets sont XORés deux
 à deux. Le résultat de ce XOR est retourné. La destination du résultat n'est
 pas importante si l'étudiant ne l'évoque pas.
 
-On a beaucoup des déréférenciations, le `xor`, une boucle, rien de particulier.
+On a beaucoup de déréférencements, le `xor`, une boucle, rien de particulier.
 
 ```
 0x08048460 <+0>:	push   ebp
@@ -401,7 +401,7 @@ gdb-peda$ x/20i 0x804845b
 ```
 
 On retombe sur un prologue de fonction, on voit un check sur le nombre
-d'aguments... On est au bon endroit !
+d'arguments... On est au bon endroit !
 
 Un peu plus bas dans le listing du `main` :
 
@@ -573,7 +573,7 @@ Breakpoint 1, main.test (flag=..., input=...) at /home/oursin/go/src/re/main.go:
 10	/home/oursin/go/src/re/main.go: No such file or directory.
 ```
 
-Il en faut pas plus... On repère la chaîne `RmFpdGVzRHVHb0JhbmRlRGVCYXRhcmRz`
+Il n'en faut pas plus... On repère la chaîne `RmFpdGVzRHVHb0JhbmRlRGVCYXRhcmRz`
 sur la pile. Et on récupère le flag :
 
 ```
@@ -594,8 +594,8 @@ hors GDB
 * morceau de code chiffré (XOR), déchiffré à l'exécution
 * binaire strippé
 
-De part la construction du binaire, on ne va pas aller chercher
-`__libc_start_main@plt` nous même pour repérer la fonction `main` comme on l'a
+De par la construction du binaire, on ne va pas aller chercher
+`__libc_start_main@plt` nous-mêmes pour repérer la fonction `main` comme on l'a
 fait précédemment. On va plutôt utiliser la technique du `backtrace` qui est
 plus "automatique". On commence par `ltrace` le binaire pour espérer retrouver
 une fonction connue :
@@ -656,7 +656,7 @@ gdb-peda$ x/20i $rip
    0x555555555414:	call   0x555555555030 <getenv@plt>
 ```
 
-A partir de là, on peut commencer à se balader dans le code, regarder les
+À partir de là, on peut commencer à se balader dans le code, regarder les
 routines...
 
 La fonction qui nous intéresse est la dernière à être appelée par `main` :
@@ -708,7 +708,7 @@ gdb-peda$ x/70i 0x5555555552d7
 
 On a deux boucles qui viennent XOR notre bout de code chiffré. La première
 peut être ignorée étant donné que la variable globale utilisée comme clé
-est en fait la valeur de retour de `getenv()`. Etant donné que nous avons
+est en fait la valeur de retour de `getenv()`. Étant donné que nous avons
 `unset LINES` et `COLUMNS`, sa valeur devrait être `0`, ce qui ne modifie pas
 le code.
 
@@ -809,7 +809,7 @@ RBX: 0x32 ('2')
 ```
 
 La clé commence à `0x32` puis est incrémentée de `0x03` à chaque fois. Il
-nous manque plus que les octets XORés :
+ne nous manque plus que les octets XORés :
 
 ```
 gdb-peda$ b * 0x55555555811d

--- a/src/content/pages/2019-reverse-01-student.md
+++ b/src/content/pages/2019-reverse-01-student.md
@@ -8,20 +8,20 @@ reverse, nous pouvons commencer à tâter des binaires un peu plus imposants et
 qui n'ont pas pour seul objectif de vous exposer une routine de vérification.
 
 N'hésitez pas à passer plus de temps sur les exercices de la journée
-précédente. Une fois ces bases maitrisées, vous êtes autonomes dans le
+précédente. Une fois ces bases maîtrisées, vous êtes autonomes dans le
 milieu du reverse. C'est désormais à vous d'aller chercher de la documentation
 plus spécifique, de vous renseigner sur de nouvelles techniques, etc.
 
 Même si c'est pas toujours super légal, vous pouvez vous attaquer à des
-binaires commerciaux (logiciels, jeux vidéos...), ils embarquent souvent des
-mécanismes de protections intéressants à reverse. Il y a parfois de grosses
+binaires commerciaux (logiciels, jeux vidéo...), ils embarquent souvent des
+mécanismes de protection intéressants à reverse. Il y a parfois de grosses
 surprises mais la logique est certainement la suivante : plus la date de
 commercialisation est ancienne, plus les protections seront faciles à reverse.
 
 **Note : reverse du binaire commercial, c'est cool, et je suis le premier à
 aimer ça. Tant qu'on le fait dans son coin, j'imagine qu'on ne fait de mal à
 personne. Mais mettre en ligne une release pirate sur un tracker, c'est moins
-cool. Si vous lisez cette page, c'est surement que vous bossez dans l'info.
+cool. Si vous lisez cette page, c'est sûrement que vous bossez dans l'info.
 Vous savez donc que les logiciels prennent un temps fou à être écrits,
 édités... Et que les développeurs ont aussi besoin de manger à la fin du
 mois. 🍗**
@@ -29,17 +29,17 @@ mois. 🍗**
 
 ## Exercice 00
 
-Nous allons justement nous attaquer à un vieux jeu pour ordinateur: *Heroes of
+Nous allons justement nous attaquer à un vieux jeu pour ordinateur : *Heroes of
 Might and Magic III*. Il est disponible sous Windows, macOS, Linux... Vous
 n'avez fait que du Linux dans cette série, jusqu'à maintenant. Il est
 temps de voir un peu autre chose...
 
 Tout ce que vous avez appris sur l'assembleur, les patterns de code, les
-mécanismes liés au fonction, etc. Tout cela est toujours valable sous Windows.
+mécanismes liés aux fonctions, etc. Tout cela est toujours valable sous Windows.
 Il existe de nombreuses autres spécificités mais vous êtes déjà opérationnel.
 
-Le plus gros changement que vous aller tout de suite remarquer est le passage
-de la LibC à l'API Win32. Vous avez surement déjà du voir des références à
+Le plus gros changement que vous allez tout de suite remarquer est le passage
+de la LibC à l'API Win32. Vous avez sûrement déjà dû voir des références à
 `Kernel32.dll`, `User32.dll` ou même `GDI32.dll`. Ces trois fichiers sont plus
 ou moins votre `libc.so` sous Windows. Ils permettent aux développeurs
 d'accéder à un ensemble normalisé et standard (du moins, du point de vue de
@@ -54,7 +54,7 @@ Le MSDN sera votre documentation de référence pour cette API.
 
 Grande nouvelle ! Vous êtes maintenant encouragés à utiliser IDA Pro ! GDB
 c'est cool mais c'est un peu pour les enfants. Rentrez dans la cour des
-grands, installez IDA et lachez des gros F5.
+grands, installez IDA et lâchez des gros F5.
 
 Installez IDA puis soyez attentif pendant la démonstration.
 
@@ -62,7 +62,7 @@ Installez IDA puis soyez attentif pendant la démonstration.
 ## Exercice 01
 
 La licence *Heroes of Might and Magic* appartenait à l'origine à 3DO. Suite à
-la fallite de cette entreprise, c'est Ubisoft qui la récupère. Le dernier (VII)
+la faillite de cette entreprise, c'est Ubisoft qui la récupère. Le dernier (VII)
 opus sorti date de 2015. La série est considérée comme morte depuis 2016,
 Ubisoft ayant annoncé avoir rompu avec Limbic Entertainment, l'entreprise qui a
 développé les opus VI et VII.
@@ -73,20 +73,20 @@ en ligne.
 
 Il existe plusieurs releases de l'épisode III : le jeu simple, le jeu et une
 ou plusieurs extensions, une *Complete Edition* avec toutes les extensions,
-un version HD officielle, une version HD patchée officieusement, une version
+une version HD officielle, une version HD patchée officieusement, une version
 GoG...
 
-La version HD officielle est récente et présente des mécanismes de protections
+La version HD officielle est récente et présente des mécanismes de protection
 solides. Nous n'allons pas nous y intéresser. La version HD patchée ainsi que
 la version GoG sont toutes les deux dépourvues de protection donc nous
 n'allons pas y toucher non plus. Nous allons nous concentrer sur la version
 "originale" qui présente le même mécanisme de protection, peu importe le
-nombre d'extensions avec laquelle elle est livrée.
+nombre d'extensions avec lequel elle est livrée.
 
 ![Illustration](/assets/reverse-01/illustration.jpg)
 
 Vous pouvez télécharger ici une [Complete Edition](https://cdn.geographer.fr/heroes_3.zip), qui correspond au jeu
-originale, plus toutes ces extensions. La version physique de cette édition
+original, plus toutes ses extensions. La version physique de cette édition
 se présentait sous la forme d'une boîte contenant 3 CDs :
 
 * le jeu original, intitulé *Heroes of Might and Magic III: Restoration of
@@ -138,7 +138,7 @@ l'environnement de référence !
 
 Votre objectif : trouver le bon mot de passe.
 
-Indice : aucun, débrouillez vous ! :p
+Indice : aucun, débrouillez-vous ! :p
 
 
 ## Exercice 03

--- a/src/content/pages/2019-reverse-01-teacher.md
+++ b/src/content/pages/2019-reverse-01-teacher.md
@@ -69,7 +69,7 @@ Les deux fonctions sont utilisées dans une même routine : `sub_50C1C0`.
 `GetDriveTypeA` est également utilisée dans `__validdrive` mais cette dernière
 fonction ne nous intéresse pas, malgré son nom aguicheur.
 
-Regardons un peu le code de `sub_50C1C0` (que nous appelerons maintenant
+Regardons un peu le code de `sub_50C1C0` (que nous appellerons maintenant
 `checkForCD`).
 
 ```c
@@ -185,7 +185,7 @@ font sauter sur `LABEL_29`. Si on ne valide aucune condition, on finit par
 obtenir `0` comme valeur de retour, ce qui ressemble à un succès.
 
 Si on saute sur `LABEL_29`, on a alors d'autres vérifications qui sont
-effectuées. Quoiqu'il arrive, on retourne alors `2`.
+effectuées. Quoi qu'il arrive, on retourne alors `2`.
 
 Bien que `0` semble clairement indiquer un succès, nous allons regarder la
 fonction parente (celle qui appelle celle-ci) afin de donner un contexte à
@@ -270,7 +270,7 @@ la valeur de `result`. On pourrait étudier la logique de ce `if` pour éviter
 de se faire écraser (on part du principe que `0` indique toujours un succès)
 mais il est plus simple de carrément sauter tout ce code pour l'instant.
 
-On va donc appliquer les patch suivant :
+On va donc appliquer les patchs suivants :
 
 * on va remplacer le `call checkForCD` par un `mov eax, 0x0`, ainsi on
   s'assure un `result` de `0`
@@ -300,7 +300,7 @@ a en fait plusieurs cas :
 D'où les différentes valeurs.
 
 
-# Exercice 02
+## Exercice 02
 
 Je touche pas à ça !
 

--- a/src/content/pages/2019-sploit-00-student.md
+++ b/src/content/pages/2019-sploit-00-student.md
@@ -11,7 +11,7 @@ anglo-saxonne *binary exploitation*, souvent abrégée *exploit* ou même
 Le principe est simple... Vous savez que lorsqu'on écrit du code, on introduit
 bien souvent des bugs. Ces bugs ont des causes tout à fait différentes mais
 le résultat est presque toujours le même : une opération indésirable en
-mémoire. Ecrire quelques octets de trop, lire un pointeur nul... Voilà de
+mémoire. Écrire quelques octets de trop, lire un pointeur nul... Voilà de
 quoi faire terminer prématurément le programme !
 
 Ces erreurs de programmation sont très fréquentes quand on programme dans
@@ -29,7 +29,7 @@ potentielle. Admettons une écriture de 50 octets dans un tampon prévu pour en
 accueillir... 20 ? Admettons aussi que les 50 octets écrits proviennent d'une
 entrée utilisateur. Nous laissons donc l'utilisateur écrire 30 octets
 arbitraires en mémoire. Les érudits appellent ça une primitive d'écriture et
-c'est bien souvent suffisant pour faire crasher un shell à un programme
+c'est bien souvent suffisant pour faire cracher un shell à un programme
 développé dans le seul but d'afficher des photos. Vous comprendrez mieux
 après la démo.
 
@@ -50,7 +50,7 @@ Vous serez ensuite en mesure de répondre à la question suivante... Quand on
 ## Exercice 00
 
 Cet exercice ainsi que tous les suivants se passent sur une machine distante.
-Pous vous connecter :
+Pour vous connecter :
 
 ```
 ssh ex00@louane.geographer.fr
@@ -67,7 +67,7 @@ Pour vous aider, vous pouvez répondre aux questions suivantes :
 
 * quelle est la taille du tampon alloué pour l'entrée utilisateur ?
 * combien d'octets sont en fait écrits à l'adresse de ce tampon ?
-* qu'est ce qui se trouve sur les quatre octets suivants la fin de l'espace
+* qu'est-ce qui se trouve sur les quatre octets suivant la fin de l'espace
   alloué pour le tampon ?
 
 

--- a/src/content/pages/2019-sploit-00-teacher.md
+++ b/src/content/pages/2019-sploit-00-teacher.md
@@ -14,13 +14,13 @@ Les points à évoquer lors de la présentation :
   des vulnérabilités dans les binaires
 * GDB : l'importance du débogueur
 * GDB : inspecter la mémoire (`x/`, `p`) et le boutisme
-* GDB : les points d'arrêts
-* `python -c` et l'importance de gêrer son shell
+* GDB : les points d'arrêt
+* `python -c` et l'importance de gérer son shell
 * démonstration d'un crash, dans GDB
 * bien mettre l'accent sur l'écrasement d'EIP
 
 Et on termine avec des explications sur comment travailler en machine
-virtuelle : les permissions restraintes, `/tmp`, les binaires *setuid*...
+virtuelle : les permissions restreintes, `/tmp`, les binaires *setuid*...
 
 Beaucoup de réponses sont en fait valides mais la réponse attendue est la
 suivante... En débordant du tampon initialement alloué, on peut écrire la
@@ -53,7 +53,7 @@ int main(void) {
 }
 ```
 Un tampon de 10 mais une écriture de 14... La variable à écraser se trouve
-juste au dessus du tampon donc :
+juste au-dessus du tampon donc :
 
 ```
 ex00@debian:~$ python -c 'print "A" * 14' | ./ex00
@@ -87,8 +87,8 @@ int main(void) {
 ```
 
 Même exercice que le précédent mais la valeur à écrire n'est plus arbitraire.
-Pas la peine de calculer les offets ou quoi, on écrit simplement la valeur
-demander en boucle, on tombera juste grace au padding :
+Pas la peine de calculer les offsets ou quoi, on écrit simplement la valeur
+demandée en boucle, on tombera juste grâce au padding :
 
 ```
 ex00b@debian:~$ (python -c "print '\xef\xbe\xad\xde' * 200"; cat -) | ./ex00b
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 
 Débordement classique.
 
-Epreuve de Zenk-Security donc pas de correction publique.
+Épreuve de Zenk-Security donc pas de correction publique.
 
 Flag : `3MnmpyMyVmUZKX9KXOXjHpGdytKrZ1dd`.
 
@@ -277,7 +277,7 @@ int main(int ac, char **argv) {
 }
 ```
 
-On a une race condition entre le moment ou le `realpath` est vérifié et le
+On a une race condition entre le moment où le `realpath` est vérifié et le
 moment où le fichier est bel et bien lu. On peut utiliser un lien symbolique
 variant aussi vite que possible entre : un fichier bidon que l'on peut lire
 mais avec un contenu qui ne nous intéresse pas, et `/home/ex05/.passwd`.
@@ -295,8 +295,8 @@ while true; do ./ex04 /tmp/geo/random 2> /dev/null; done
 0WPRihGwXg6X7qactvwjZ5QVOGK6zt16
 ```
 
-La vulnérabilité repose sur le fait que la sécurité a été implémenté (mal,
-qui le plus) dans la logique de l'application et non en terme de permissions.
+La vulnérabilité repose sur le fait que la sécurité a été implémentée (mal,
+qui plus est) dans la logique de l'application et non en termes de permissions.
 
 
 ## Exercice 05
@@ -320,7 +320,7 @@ On ne peut pas mettre le shellcode dans la pile car pas exécutable. On
 va donc faire un *ret2libc*.
 
 On se prend l'adresse de `system()`, l'adresse de `"/bin/sh"`... On trouve
-à taton l'offset qu'il faut pour écraser EIP puis :
+à tâtons l'offset qu'il faut pour écraser EIP puis :
 
 
 ```

--- a/src/content/pages/2019-web-00-student.md
+++ b/src/content/pages/2019-web-00-student.md
@@ -8,7 +8,7 @@ regroupe généralement toutes les attaques que l'on peut infliger aux
 sites web et autres applications que l'on consomme à travers un navigateur.
 
 Il s'agit certainement de la branche la plus populaire de la sécurité
-informatique. Les média grand public en parlent régulièrement, les entreprises
+informatique. Les médias grand public en parlent régulièrement, les entreprises
 y mettent des sommes folles... Et ce n'est pas près de s'arrêter ! De plus en
 plus de choses se passent sur le web. De nouveaux frameworks, de nouveaux
 langages et de nouvelles technologies émergent tous les ans, chacun avec son
@@ -27,7 +27,7 @@ Les compétences requises en sécurité web sont, entre autres :
 Côté client, le langage roi est JavaScript. Nous verrons quelques
 vulnérabilités *client-side* au cours de cette journée.
 
-Côté serveur, on a une pluralité beaucoup plus imporante : PHP, JavaScript,
+Côté serveur, on a une pluralité beaucoup plus importante : PHP, JavaScript,
 Python, Go, C++... On retrouve également des langages de base de données.
 
 D'une manière générale, comprendre le langage dans lequel est écrit
@@ -38,7 +38,7 @@ pour les épreuves serveur. Nous cherchions un langage très utilisé en
 production mais présentant, par design, de nombreuses vulnérabilités. Un
 langage très permissif qui vous permettrait de laisser libre cours à votre
 créativité. Un langage regroupant toute la faune et la flore des problèmes de
-sécurité dans les applications web. Nous parlons bien sur de PHP.
+sécurité dans les applications web. Nous parlons bien sûr de PHP.
 
 
 ## Exercice 00
@@ -49,12 +49,12 @@ appuie sur le bouton "Se Connecter" d'un site web. L'utilisateur constate que
 la page se recharge. Une fois le chargement terminé, il est connecté, et sur
 sa page de profil.
 
-Vous devez faire apparaitre les légendes suivantes :
+Vous devez faire apparaître les légendes suivantes :
 
 * début de la requête vers le serveur web
 * début de la requête vers la base de données
 * utilisateur/navigateur
-* fin de la requête vers le serveur WEB
+* fin de la requête vers le serveur web
 * traitement de PHP
 * fin de la requête vers la base de données
 * côté serveur
@@ -72,10 +72,10 @@ Continuons nos recherches sur le HTTP...
 
 Répondez aux questions suivantes :
 
-* quels sont les caractéristiques des
+* quelles sont les caractéristiques des
   requêtes `GET`, `POST`, `PUT` et `DELETE` ?
-* prenons une requête `POST`, qu'est ce que le `Content-Type` ?
-* par quel(s) moyen(s) standards peut on communiquer de la donnée au serveur
+* prenons une requête `POST`, qu'est-ce que le `Content-Type` ?
+* par quel(s) moyen(s) standards peut-on communiquer de la donnée au serveur
   dans le cas d'une requête `GET` ?
 * déchiffrez `3%20%2B%202%20%3D%205%20est%20une%20%C3%A9galit%C3%A9%20vraie`,
   quelle est l'utilité de cette représentation ?
@@ -91,7 +91,7 @@ Vous devez affronter [cette épreuve](https://www.root-me.org/fr/Challenges/Web-
 
 Pour vous aider, répondez aux questions suivantes :
 
-* cette application implémente-elle sa sécurité côté client ou côté serveur ?
+* cette application implémente-t-elle sa sécurité côté client ou côté serveur ?
 * dans quel fichier cette sécurité est-elle implémentée ?
 * comment sont stockés le nom d'utilisateur et le mot de passe ?
 
@@ -112,7 +112,7 @@ Voici des questions pour vous aider :
 * comment pouvez-vous vous envoyer ce que vous souhaitez recevoir ?
 
 Expliquez le principe d'une XSS. Expliquez la différence entre une XSS
-**réfléchie** et une XSS **stockée**. Y'a-t-il des interactions avec le serveur
+**réfléchie** et une XSS **stockée**. Y a-t-il des interactions avec le serveur
 dans le cadre d'une XSS ?
 
 
@@ -136,7 +136,7 @@ Expliquez le principe d'une CSRF. Donnez un exemple de mécanisme permettant
 de s'en protéger.
 
 
-## Exercie 05
+## Exercice 05
 
 Assez de sécurité côté client... Vous avez compris le principe : qui dit
 point d'entrée mal filtré, dit vulnérabilité. Il ne faut jamais faire
@@ -145,9 +145,9 @@ JavaScript là où bon lui semble.
 
 Passons côté serveur...
 
-Vous devez affronte l'épreuve numéro 17 de [WebSec](https://websec.fr/).
+Vous devez affronter l'épreuve numéro 17 de [WebSec](https://websec.fr/).
 
-Un indice : les adeptes de PHP sont souvent de très bon jongleurs...
+Un indice : les adeptes de PHP sont souvent de très bons jongleurs...
 
 
 ## Exercice 06
@@ -155,7 +155,7 @@ Un indice : les adeptes de PHP sont souvent de très bon jongleurs...
 Vous devez affronter l'épreuve numéro 08 de [WebSec](https://websec.fr/).
 
 Un indice : PHP est le genre de gars qui adore les emballages mais qui se
-soucie assez peu du cadeau en lui même...
+soucie assez peu du cadeau en lui-même...
 
 Un autre indice : au final, ça veut dire quoi "valide" ?
 

--- a/src/content/pages/2019-web-00-teacher.md
+++ b/src/content/pages/2019-web-00-teacher.md
@@ -12,7 +12,7 @@ la sécurité web :
 * le navigateur Chrome embarque des protections contre les XSS/CSRF qui sont
   pénibles quand on veut justement en exploiter une
 
-On peut aussi troller un peu sur PHP, ça fait jamais de mal. Ca vaut le coup
+On peut aussi troller un peu sur PHP, ça fait jamais de mal. Ça vaut le coup
 de parler [de la fin de PHP5](https://www.youtube.com/watch?v=yx2ks03d4mE).
 On en profite pour faire de la pub pour
 [Snuffleupagus](https://github.com/nbs-system/snuffleupagus), c'est gagné.
@@ -39,7 +39,7 @@ On part du principe que la redirection se fait côté serveur.
 ## Exercice 01
 
 `GET`, `POST`, `PUT` et `DELETE` sont les quatre verbes HTTP que l'on
-retrouve traditionnellment dans le `REST` :
+retrouve traditionnellement dans le `REST` :
 
 * `GET` pour récupérer une ressource auprès du serveur
 * `POST` pour mettre à jour une ressource, parfois créer
@@ -80,17 +80,17 @@ ce qui est hors du scope de la journée, donc bof.
 
 ## Exercice 02
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 Il ne faut jamais faire de sécurité côté client car on expose le mécanisme de
 sécurité. Aussi fort qu'il soit, ce n'est qu'une question de temps avant
 qu'il soit cassé. Le morceau de JavaScript le plus obfusqué du monde finira
-toujours pas être nettoyé et compris.
+toujours par être nettoyé et compris.
 
 
 ## Exercice 03
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 Nous avons une XSS à partir du moment où nous sommes en mesure d'injecter
 dans la page du contenu interprétable par le navigateur. Dans le cas d'école,
@@ -108,7 +108,7 @@ est ensuite envoyé à l'utilisateur en espérant qu'il clique dessus.
 
 ## Exercice 04
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 Dans l'ordre :
 
@@ -145,22 +145,22 @@ Quelques moyens permettant de profiter d'une CSRF :
 
 ## Exercice 05
 
-Epreuve WebSec donc pas de correction publique.
+Épreuve WebSec donc pas de correction publique.
 
 L'indice fait référence au *type juggling* de PHP.
 
 
 ## Exercice 06
 
-Epreuve WebSec donc pas de correction publique.
+Épreuve WebSec donc pas de correction publique.
 
-L'indice chercher à faire comprendre que valider la nature d'un fichier en
+L'indice cherche à faire comprendre que valider la nature d'un fichier en
 se fondant uniquement sur quelques octets n'est pas vraiment une bonne idée.
 
 
 ## Exercice 07
 
-Epreuve WebSec donc pas de correction publique.
+Épreuve WebSec donc pas de correction publique.
 
 L'indice fait référence à une *race condition*.
 

--- a/src/content/pages/2019-web-01-student.md
+++ b/src/content/pages/2019-web-01-student.md
@@ -7,7 +7,7 @@ Durant votre [première journée](/2019-web-00-student) de
 sécurité web, vous avez eu l'occasion de travailler sur des vulnérabilités
 archi classiques. Cette journée sera exclusivement dédiée aux injections SQL.
 
-La grande majorité des applications WEB utilisent un ou plusieurs systèmes de
+La grande majorité des applications web utilisent un ou plusieurs systèmes de
 gestion de base de données (SGBD), pour du stockage plus ou moins persistant.
 Lorsque des entrées utilisateur sont utilisées dans les requêtes passées au
 SGBD, les choses se compliquent.
@@ -20,7 +20,7 @@ d'autres syntaxes.
 Si vous n'avez jamais fait de SQL, vous pourrez apprendre sur le tas. Vous
 allez juste galérer un peu.
 
-Si vous êtes à l'aise avec SQL, vous irez surement assez vite une fois le
+Si vous êtes à l'aise avec SQL, vous irez sûrement assez vite une fois le
 principe compris. Vous pourrez en profiter pour revenir sur la journée
 précédente ou bien commencer la journée de demain.
 
@@ -36,13 +36,13 @@ ainsi que [Docker Compose](https://docs.docker.com/compose/).
 *Note : Si vous ne connaissez pas Docker... Il s'agit, pour faire très simple,
 d'un outil vous permettant d'exécuter sur votre machine des applications
 demandant des dépendances et configurations complexes sans avoir à toucher
-à votre système. La, ou les, applications(s) tournent alors dans des
+à votre système. La, ou les, application(s) tournent alors dans des
 containers, plus ou moins isolés de votre système hôte.*
 
 Lancez Docker.
 
 Récupérez ensuite [le code](https://github.com/Geospace/sqli-platform) de
-l'application vulnérable et placez-vous dans le dépot.
+l'application vulnérable et placez-vous dans le dépôt.
 
 Lancez l'application :
 
@@ -53,7 +53,7 @@ docker-compose up
 Attendez que tout démarre. Vous avez devant vous les journaux de l'application
 et de sa base de données.
 
-Rendez vous ensuite sur `http://localhost:8080/` et soyez attentif lors de la
+Rendez-vous ensuite sur `http://localhost:8080/` et soyez attentif lors de la
 démonstration.
 
 Vous devez obtenir les mots de passe stockés dans la base de données à l'aide
@@ -82,7 +82,7 @@ Vous allez affronter [cette épreuve](https://www.root-me.org/fr/Challenges/Web-
 
 Quelques questions pour vous guider :
 
-* vous savez qu'il existe d'autres champs que ceux de connexion, n'est ce pas ?
+* vous savez qu'il existe d'autres champs que ceux de connexion, n'est-ce pas ?
 * combien de colonnes dans cette requête ?
 * on va chercher le schéma de table ou on le devine ?
 
@@ -91,7 +91,7 @@ Quelques questions pour vous guider :
 
 Vous allez affronter [cette épreuve](https://www.root-me.org/fr/Challenges/Web-Serveur/SQL-injection-numerique).
 
-Vous êtes des grands maintenant, débrouillez vous ! ;)
+Vous êtes des grands maintenant, débrouillez-vous ! ;)
 
 
 ## Exercice 04
@@ -104,11 +104,11 @@ plus facilement.
 
 Quelques questions :
 
-* quel est le problème ? Qu'est ce qui rend cette épreuve différentes des
+* quel est le problème ? Qu'est-ce qui rend cette épreuve différente des
   précédentes ?
-* pouvez-vous connaitre la longueur de ce que vous recherchez ? Ce serait
+* pouvez-vous connaître la longueur de ce que vous recherchez ? Ce serait
   quand même plus facile...
-* sur quelle *range* de caractère pouvez-vous raisonnablement itérer ?
+* sur quelle *range* de caractères pouvez-vous raisonnablement itérer ?
 
 
 ## Exercice 05

--- a/src/content/pages/2019-web-01-teacher.md
+++ b/src/content/pages/2019-web-01-teacher.md
@@ -21,9 +21,9 @@ de SQL avant, pour roder un peu.
 Ce premier exercice permet à l'étudiant de visualiser ce qu'il fait. On cherche
 à avoir ce "déclic".
 
-Ceux qui n'ont jamais utilisé Docker vont peut être galêrer à mettre en place
-l'application. Je sais qu'il n'y a littéralement qu'**une** commande à tapper
-mais quand on connait pas Docker, ça peut perturber... On peut accepter de
+Ceux qui n'ont jamais utilisé Docker vont peut-être galérer à mettre en place
+l'application. Je sais qu'il n'y a littéralement qu'**une** commande à taper
+mais quand on ne connaît pas Docker, ça peut perturber... On peut accepter de
 taper les commandes à leur place, quitte à faire un petit cours Docker pour
 les intéressés à la fin de la séance. On évite de perdre du temps avec le
 déploiement.
@@ -47,7 +47,7 @@ nombre de colonnes jusqu'à ce que la requête soit valide :
 
 L'`UNION` est l'outil qui nous permet "d'augmenter" notre requête pour
 ajouter ce qui nous intéresse dans les résultats. Or, pour que notre requête
-soit valide, nous devons avoir le même nombre de colonnes deux des côtés de
+soit valide, nous devons avoir le même nombre de colonnes des deux côtés de
 l'`UNION`.
 
 Cette méthode nous permet aussi de voir quels sont les champs qui sont
@@ -55,7 +55,7 @@ affichés sur la page. Ici, ce sont tous les champs (on peut voir un `1`, un `2`
 et un `3` dans le rendu).
 
 Nous connaissons le nom de la base de données mais il aurait pu être deviné
-facilement. Il ne nous restes plus qu'à insérer les noms des colonnes et on
+facilement. Il ne nous reste plus qu'à insérer les noms des colonnes et on
 a notre payload finale :
 
 ```sql
@@ -67,7 +67,7 @@ Et c'est gagné !
 
 ## Exercice 01
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 C'est une SQLi classique, on peut appliquer la même méthodologie que
 pour l'exercice d'introduction. Il faut seulement s'imaginer la requête.
@@ -75,7 +75,7 @@ pour l'exercice d'introduction. Il faut seulement s'imaginer la requête.
 
 ## Exercice 02
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 Même méthodologie. Pour les étudiants qui vont trop vite, on peut leur
 demander de faire fuiter le schéma de la table au lieu de deviner les noms
@@ -84,21 +84,21 @@ de colonne.
 
 ## Exercice 03
 
-Epreuve Root-Me donc pas de correction publique. Mais vraiment, rien de
+Épreuve Root-Me donc pas de correction publique. Mais vraiment, rien de
 particulier, c'est juste de la pratique à ce stade... ;)
 
 
 ## Exercice 04
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 Cette épreuve est différente car l'injection SQL doit se faire à l'aveugle.
-La technique que nous avons utilisé précédemment ne fonctionnera pas
+La technique que nous avons utilisée précédemment ne fonctionnera pas
 en raison d'un filtre.
 
 L'approche du temps (*time based attack*) pourrait résoudre le problème. Mais,
 encore plus simple... On utilise un `OR` pour valider une expression. Si
-l'exression est vraie, on est connecté. Autrement, la connection échoue.
+l'expression est vraie, on est connecté. Autrement, la connexion échoue.
 
 Nous allons tester la valeur recherchée caractère par caractère. On peut
 utiliser la dichotomie pour gagner du temps.
@@ -111,7 +111,7 @@ imprimables.
 
 ## Exercice 05
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 C'est du LDAP. Rien de particulier, il suffit de se lire
 [un petit document](https://www.blackhat.com/presentations/bh-europe-08/Alonso-Parada/Whitepaper/bh-eu-08-alonso-parada-WP.pdf)
@@ -120,9 +120,9 @@ pour prendre la syntaxe.
 
 ## Exercice 06
 
-Epreuve Root-Me donc pas de correction publique.
+Épreuve Root-Me donc pas de correction publique.
 
 
 ## Exercice 07
 
-S'il vous plait, un retour !
+S'il vous plaît, un retour !

--- a/src/content/pages/h25-js.md
+++ b/src/content/pages/h25-js.md
@@ -31,19 +31,19 @@ et il est aujourd'hui absolument partout : dans nos navigateurs, dans nos
 serveurs web, dans nos appareils mobiles, dans nos applications de bureau...
 
 Mais il est aussi dans nos CTFs ! Et on le retrouve dans plusieurs
-catégories : web, bien sur, mais aussi crypto, forensique, malware,
-mobile, etc. Le JavaScript peut bien sur être le sujet de l'épreuve en
-elle-même, mais il peut également être simplement le moyen d'intéragir
+catégories : web, bien sûr, mais aussi crypto, forensique, malware,
+mobile, etc. Le JavaScript peut bien sûr être le sujet de l'épreuve en
+elle-même, mais il peut également être simplement le moyen d'interagir
 avec l'épreuve (comme on l'a vu lors [du dernier stream
 H25](https://www.youtube.com/watch?v=tzFHvqaYnoM)).
 
 Le problème, c'est que beaucoup de joueurs de CTFs ne connaissent pas
-*vraiment* le JavaScript. C'est à dire : beaucoup de joueurs sont
-capables d'inférer ce que fait un bout de code en se ratachant à des
+*vraiment* le JavaScript. C'est-à-dire : beaucoup de joueurs sont
+capables d'inférer ce que fait un bout de code en se rattachant à des
 mots clés, à des noms de méthode, ou à des constructions de
-programmation orientée objet qui leurs sont familiers parce que
-similaires à ce qui se fait dans d'autres langages. Le bat blesse quand
-il s'agit d'écrire du code, et plus seulement en lire. Ou bien,
+programmation orientée objet qui leur sont familiers parce que
+similaires à ce qui se fait dans d'autres langages. Là où le bât blesse,
+c'est quand il s'agit d'écrire du code, et plus seulement d'en lire. Ou bien,
 lorsque le code étudié présente des fonctionnalités avancées de
 JavaScript, en particulier celles relatives à la programmation
 asynchrone.
@@ -233,17 +233,17 @@ dans les deux environnements.
 En revanche, le contexte sera différent. Un bout de code JavaScript
 exécuté dans le navigateur peut accéder à l'objet `document`, qui
 représente la page web. Node.js ne peut accéder à cet objet car il ne
-fait pas sens dans son contexte. En revanche, Node.js fourni le module
-`fs` qui est une API pour intéragir avec le système de fichier. Le
+fait pas sens dans son contexte. En revanche, Node.js fournit le module
+`fs` qui est une API pour interagir avec le système de fichiers. Le
 navigateur ne propose pas cette API, car il n'a pas accès au système de
-fichier (c'est [en train
+fichiers (c'est [en train
 d'évoluer](https://developer.mozilla.org/en-US/docs/Web/API/FileSystem)
 ceci dit).
 
 En fonction de l'environnement, les connaissances requises pour gérer
 une épreuve peuvent être très différentes. Une épreuve qui se passe dans
 le navigateur pourra demander d'être à l'aise avec les manipulations
-du DOM tandis qu'une épreuve serveur demandera de connaitre le
+du DOM tandis qu'une épreuve serveur demandera de connaître le
 fonctionnement de la librairie [Express](https://expressjs.com/fr/).
 
 
@@ -267,10 +267,10 @@ for (i = 0; i < some_string.length; i++) {
 }
 ```
 
-On remarque:
+On remarque :
 
-- La méthode `charCodeAt(i)` qui, lorsque appliquée sur une chaîne de
-  caractère, nous renvoie la valeur numérique du i<sup>ème</sup> caractère de
+- La méthode `charCodeAt(i)` qui, lorsqu'appliquée sur une chaîne de
+  caractères, nous renvoie la valeur numérique du i<sup>ème</sup> caractère de
   la chaîne.
 - La fonction `alert`, uniquement disponible dans le navigateur, qui
   permet de rapidement afficher un message. La fonction est utile pour du
@@ -293,10 +293,10 @@ l'opération inverse de `charCodeAt(i)`. On obtient alors le caractère
 1) correspondant au nombre `i`.
 
 Utilisateurs de Python, attention, JavaScript permet l'opérateur `+`
-sur des chaînes de caractère mais il ne permet pas la multiplication. On
-utilise pour ça la méthode statique `String.repeat()`.
+sur des chaînes de caractères mais il ne permet pas la multiplication. On
+utilise pour ça la méthode `repeat()`.
 
-On commence à comprendre que JavaScript fourni de très nombreux
+On commence à comprendre que JavaScript fournit de très nombreux
 utilitaires. Le langage dispose également d'un écosystème imposant. Il
 est très rare de ne pas trouver une dépendance permettant de répondre à
 son problème.
@@ -315,7 +315,7 @@ pas plus rapidement qu'un code non-minifié. Il est simplement plus
 rapide à télécharger.*
 
 Dans le contexte d'un CTF, la minification devient une forme
-d'obfuscation. Le code suivant:
+d'obfuscation. Le code suivant :
 
 ```javascript
 const obj = {
@@ -344,20 +344,20 @@ un outil tel que
 [l'outil de formatage de Chrome](https://developers.google.com/web/tools/chrome-devtools/javascript/reference#format).
 
 Mais il existe aussi des outils proposant une obfuscation beaucoup plus
-franche. Par exemple, avec [JavaScript Obfucator](https://obfuscator.io/), notre code initial devient:
+franche. Par exemple, avec [JavaScript Obfuscator](https://obfuscator.io/), notre code initial devient :
 
 ```javascript
 const _0x1616=['lastname','firstname','Geo','Le\x20Berlingot'];(function(_0x177eb0,_0x1616a6){const _0x1e9abe=function(_0x204014){while(--_0x204014){_0x177eb0['push'](_0x177eb0['shift']());}};_0x1e9abe(++_0x1616a6);}(_0x1616,0xc6));const _0x1e9a=function(_0x177eb0,_0x1616a6){_0x177eb0=_0x177eb0-0x0;let _0x1e9abe=_0x1616[_0x177eb0];return _0x1e9abe;};const obj={'firstname':_0x1e9a('0x0'),'lastname':_0x1e9a('0x1')};function getFullName(_0xb6014e){return _0xb6014e[_0x1e9a('0x3')]+'\x20'+_0xb6014e[_0x1e9a('0x2')];}console['log'](getFullName(obj));
 ```
 
 Et on a quelque chose qui est déjà beaucoup moins lisible. La
-méthodologie varie en fonction du temps que l'on peut investir et le
+méthodologie varie en fonction du temps que l'on peut investir et du
 type d'obfuscation mais dans le cas général, on peut commencer par
 faire passer le code dans un outil de déobfuscation tel que
 [de4js](https://lelinhtinh.github.io/de4js/) et ensuite terminer à la
 main. On va chercher principalement à :
 
-- Renommer les noms de variables et functions
+- Renommer les noms de variables et fonctions
 - Extraire les différents éléments, notamment les chaînes de
   caractères, que les obfuscateurs ont tendance à regrouper dans des tableaux
 - Retirer le code inutile
@@ -370,7 +370,7 @@ d'une épreuve des qualifications de la Nuit Du Hack 2018.
 ### Encodages
 
 JavaScript donne accès, même sans dépendances, à plusieurs encodages dont les
-challenges ont tendance à abuser. Si on ne les connait pas, ils peuvent donner
+challenges ont tendance à abuser. Si on ne les connaît pas, ils peuvent donner
 l'impression qu'on doit gérer un chiffrement complexe ou une bizarrerie
 JavaScript alors qu'un simple appel de fonction suffit. On a :
 
@@ -384,7 +384,7 @@ Attention également à la fonction [`eval`](https://developer.mozilla.org/fr/do
 
 ### Quelques writeups
 
-Les writeups suivant couvrent bien le spectre d'épreuves qu'on peut rencontrer.
+Les writeups suivants couvrent bien le spectre d'épreuves qu'on peut rencontrer.
 
 - [JS SAFE 2.0 - Google CTF 2018, par LiveOverflow](https://www.youtube.com/watch?v=8yWUaqEcXr4)
 - [JS Kiddie - picoCTF 2019, par radekk](https://medium.com/@radekk/picoctf-2019-writeup-for-js-kiddie-7af4f0a20838)
@@ -394,10 +394,10 @@ Les writeups suivant couvrent bien le spectre d'épreuves qu'on peut rencontrer.
 
 ## Concurrence
 
-JavaScript inplémente une boucle d'évènement (en anglais: *event loop*), qui
-l'ammène à ne pas être bloquant. En Python, lorsqu'on fait une requête HTTP
-avec le module `request`, il est impossible (du moins, sans efforts) d'exécuter
-plus de code pendant que cette requête a lieu.  On dit alors que l'appel Python
+JavaScript implémente une boucle d'évènement (en anglais: *event loop*), qui
+l'amène à ne pas être bloquant. En Python, lorsqu'on fait une requête HTTP
+avec le module `requests`, il est impossible (du moins, sans efforts) d'exécuter
+plus de code pendant que cette requête a lieu. On dit alors que l'appel Python
 est bloquant, car il monopolise le *runtime* et ne "rend pas la main".
 
 **Attention ! Si vous découvrez la concurrence, il est très important que vous
@@ -512,7 +512,7 @@ request.get('https://geographer.fr/')
 ```
 
 Beaucoup mieux ! On remarque deux méthodes : `then` et `catch`, et
-l'objet sur lequel elles sont appliquées n'apparait pas clairement. Il
+l'objet sur lequel elles sont appliquées n'apparaît pas clairement. Il
 s'agit en fait d'un objet `Promise` qui vient enrober les valeurs de
 retour des appels asynchrones. Pour mieux comprendre, étudions ce code
 qui implémente une fonction retournant une promesse :
@@ -539,7 +539,7 @@ writeFilePromise('/tmp/hello.txt', 'Hello!')
 On obtient donc une fonction `writeFilePromise` qui se substitue à
 `fs.writeFile`. Cette nouvelle fonction ne prend pas de callback en paramètre
 mais retourne immédiatement une variable `Promise`. La fonction à exécuter est
-passée en paramètre au constructeur `Promise`.  Ce constructeur reçoit deux
+passée en paramètre au constructeur `Promise`. Ce constructeur reçoit deux
 autres fonctions en paramètre : `resolve`, et `reject`. La première sera
 appelée lorsqu'il faut transférer une valeur de retour qui n'est pas une
 erreur. La seconde sera appelée afin de transférer une erreur.
@@ -558,15 +558,15 @@ lorsque c'est `resolve` qui a été appelé dans le callback de promesse (donc,
 lorsqu'il n'y a pas eu d'erreur). La méthode `catch` est appelée lorsque c'est
 `reject` qui a été appelé dans le callback de promesse. Les méthodes `then` et
 `catch` admettent des fonctions en paramètre. Ces fonctions reçoivent
-elles-mêmes en paramètres les valeurs qui ont été passés à `resolve` et
+elles-mêmes en paramètres les valeurs qui ont été passées à `resolve` et
 `reject`.
 
-Enfin, on peut noter qu'il est possible d'enchainer les promesses,
+Enfin, on peut noter qu'il est possible d'enchaîner les promesses,
 comme on a pu le voir plus haut. On se retrouve alors avec une
-construction très lisible qu'on appelle une chaîne de promesse. De ce
+construction très lisible qu'on appelle une chaîne de promesses. De ce
 fait découle la possibilité de ne placer qu'un seul `catch`, à la fin
 de la chaîne. Celui-ci couvre les erreurs de l'intégralité de la
-chaîne, ce qui allège considérablement le code (mais ammène d'autres
+chaîne, ce qui allège considérablement le code (mais amène d'autres
 problèmes, malheureusement c'est hors-sujet).
 
 
@@ -600,18 +600,18 @@ que la promesse n'est pas résolue. D'autre part, il permet d'extraire
 le résultat de l'objet `Promise` (ce que l'on recevait auparavant dans
 le callback côté `then`) lorsqu'il n'y a pas d'erreur.
 
-Il semble il y avoir un problème avec ce code : le cas d'erreur n'est
-pas gêré. C'est vrai : on aurait pu utiliser un `try`/`catch` afin de
-récupérer une eventuelle erreur. Mais on peut aussi profiter d'une
+Il semble y avoir un problème avec ce code : le cas d'erreur n'est
+pas géré. C'est vrai : on aurait pu utiliser un `try`/`catch` afin de
+récupérer une éventuelle erreur. Mais on peut aussi profiter d'une
 autre propriété intéressante des promesses. Si une promesse n'est pas
-gêrée dans son scope courant, elle est remontée au scope parent.
-L'erreur sera donc gêrée au niveau du `main().catch()`. On comprend
+gérée dans son scope courant, elle est remontée au scope parent.
+L'erreur sera donc gérée au niveau du `main().catch()`. On comprend
 alors qu'une fonction marquée `async` retourne une `Promise`.
 
 
 ### Un crawler concurrent
 
-Pour conclure notre petite balade dans le monde féérique de la
+Pour conclure notre petite balade dans le monde féerique de la
 concurrence, nous allons nous faire un petit crawler qui visite des
 pages web et nous liste toutes celles contenant le mot "JavaScript".
 
@@ -665,7 +665,7 @@ for e in list(filter(lambda r: r['result'], results)):
 
 Bien entendu, il est absurde de comparer une implémentation concurrente
 JavaScript avec une implémentation non-concurrente Python. Nous allons donc les
-comparer:
+comparer :
 
 ```
 $ time node crawler.js > /dev/null

--- a/src/content/posts/dawg-ctf-pwn.md
+++ b/src/content/posts/dawg-ctf-pwn.md
@@ -53,8 +53,8 @@ int main(){
 }
 ```
 
-There is a comment that tells us how the binary was compiled. It is a 32-bit,
-with no PIE and stack protection disable. We have no information regarding
+There is a comment that tells us how the binary was compiled. It is a 32-bit binary,
+with no PIE and stack protection disabled. We have no information regarding
 ASLR.
 
 The `get_audition_info` function is the vulnerable one. Indeed, `gets` is
@@ -141,7 +141,7 @@ The first thing that came to my mind is the [`IFS` trick](https://book.hacktrick
 nash> cat${IFS}flag.txt`
 ```
 Unfortunately, `IFS` is not set, and the `{}` are also stripped. A few
-Google searchs later, I found another payload:
+Google searches later, I found another payload:
 
 ```
 nash> `<flag.txt`
@@ -173,7 +173,7 @@ The bug is as follows:
 * You buy an item (let's say a tarantula, as it is worth a lot)
 * Your inventory is now full
 * You sell the tarantula
-* It is not removed from you inventory, but you get the bells
+* It is not removed from your inventory, but you get the bells
 * You sell the tarantula
 * It is not removed from your inventory, but you get the bells
 * ...

--- a/src/content/posts/deloitte-godmod-pizza.md
+++ b/src/content/posts/deloitte-godmod-pizza.md
@@ -5,7 +5,7 @@ date: "2019-06-11T03:00:00"
 ---
 
 *g0dmode's Pizza Shop* 🍕 was a task labelled web and worth 300 points. It is
-a standard Python command injection. I felt like it was worth way too much
+a standard Python command injection. I felt like it was worth way too many
 points for the difficulty.
 
 ![Task Description](/assets/pizza-god/intro.png)
@@ -62,7 +62,7 @@ like so:
 promo_code = ord('') #')
 ```
 
-My guess turned to be correct. So I decided to inject some reverse shell
+My guess turned out to be correct. So I decided to inject some reverse shell
 payload. A friend told me to take a look at
 [this website](http://pentestmonkey.net/cheat-sheet/shells/reverse-shell-cheat-sheet).
 

--- a/src/content/posts/deloitte-halloween-town.md
+++ b/src/content/posts/deloitte-halloween-town.md
@@ -6,7 +6,7 @@ date: "2019-06-11T02:00:00"
 
 *Halloween Town* 🎃 was a task labelled cryptography and worth 135 points.
 It was actually mostly steganography/guessing. The task remained unsolved for
-the most part of the competition, until the staff decided to release hints.
+most of the competition, until the staff decided to release hints.
 
 ![Task Description](/assets/halloween-town/intro.png)
 
@@ -52,10 +52,10 @@ Create Date                     : 1993:10:31 08:02:04
 root@3853909ffedf:/macOS/halloween#
 ```
 
-I got stuck here and stoped working on this challenge. A few hours later, the
-staff recommended to use
+I got stuck here and stopped working on this challenge. A few hours later, the
+staff recommended using
 [StegCracker](https://github.com/Paradoxis/StegCracker). This is mostly a
-wrapper around `steghide`, with the ability to perform dictionnary attacks.
+wrapper around `steghide`, with the ability to perform dictionary attacks.
 
 Let's try with `rockyou.txt`:
 

--- a/src/content/posts/deloitte-patchme.md
+++ b/src/content/posts/deloitte-patchme.md
@@ -19,7 +19,7 @@ Let's load it into IDA and take a look at the imports...
 
 ![IDA Imports](/assets/patchme/ida_imports.png)
 
-We can see various functions that allows to interact with the system:
+We can see various functions that allow us to interact with the system:
 `RegOpenKeyExA`, `GetSystemTime`, `ReadFile`... We also have
 `IsDebuggerPresent` that we should keep in mind if we decide to do some
 debugging.
@@ -61,7 +61,7 @@ we can analyse it.
 
 All the decrypted calls follow the same logic. Some external operation (for
 example, checking if a file exists) is performed. If it fails, a fake and
-incorrect key is used to update some piece of global memory (which ultimaletly
+incorrect key is used to update some piece of global memory (which ultimately
 becomes the flag). However, if it succeeds, the piece of memory is updated
 correctly.
 
@@ -82,7 +82,7 @@ operations succeeded, when none of them actually did.
 
 Once we passed the calls, the `Strstr` function is used to check if the
 global memory chunk contains `CTF{`, which should be the case if all the calls
-went smooth.
+went smoothly.
 
 We can then resume execution and:
 

--- a/src/content/posts/deloitte-quals.md
+++ b/src/content/posts/deloitte-quals.md
@@ -19,8 +19,8 @@ Here are my writeups:
 * [g0dmode’s Pizza Shop 🍕](/deloitte-godmod-pizza)
 
 I played with a bunch of friends also from EPITECH (my school in France)
-and we managed to end up at the second place. Really looking forward for
-the final round, we want that 3.000£.
+and we managed to end up in second place. Really looking forward to
+the final round, we want that £3,000.
 
 ![Final Scores](/assets/deloitte/score.png)
 

--- a/src/content/posts/deloitte-query-query.md
+++ b/src/content/posts/deloitte-query-query.md
@@ -46,14 +46,14 @@ A simple `'` crashes the application, so this field is most likely injectable.
 
 ![Web Application](/assets/query-query/crash.png)
 
-Let's try to login as `user`. This particular username may not exist but
+Let's try to log in as `user`. This particular username may not exist but
 it will give us some information on how the application behaves:
 
 ```
 user' OR 1=1 --
 ```
 
-And we get logged as `TESTIING`.
+And we get logged in as `TESTIING`.
 
 ![TESTIING](/assets/query-query/testiing.png)
 
@@ -66,7 +66,7 @@ Let's try with a username that will most likely not exist:
 does_not_exist' OR 1=1 --
 ```
 
-We are logged as `TESTIING` again. Maybe the SQL query is very weird and still
+We are logged in as `TESTIING` again. Maybe the SQL query is very weird and still
 manages to get this user. Let's ignore this for now and carry on.
 
 According to the challenge description, the flag is the password of one of the
@@ -80,24 +80,24 @@ whocares' UNION SELECT 1, 2 --
 whocares' UNION SELECT 1, 2, 3 --
 ```
 
-All these payloads crashes the application.
+All these payloads crash the application.
 
 ```
 whocares' UNION SELECT 1, 2, 3, 4 --
 ```
 
-This payload does not crash the application and logs us as `2`.
+This payload does not crash the application and logs us in as `2`.
 
 ![Logged as 2](/assets/query-query/two.png)
 
-Let's replace the numbers by actual column names. We guess that the `id`
+Let's replace the numbers with actual column names. We guess that the `id`
 column exists and that the password column is named `password`.
 
 ```
 whocares' UNION SELECT id, password, id, id from users --
 ```
 
-We are now logged as `monkey28`, which is the password of `TESTIING`.
+We are now logged in as `monkey28`, which is the password of `TESTIING`.
 
 ![Logged as monkey](/assets/query-query/monkey.png)
 

--- a/src/content/posts/deloitte-sea-shells-she-sails.md
+++ b/src/content/posts/deloitte-sea-shells-she-sails.md
@@ -27,7 +27,7 @@ that is read.
 We could actually run this code in a Windows environment but it is also
 totally possible to emulate its behaviour from a *Nix shell, which I did.
 
-Providing that the base64 string is a file called `b64` we have:
+Provided that the base64 string is a file called `b64` we have:
 
 ```
 $ cat b64 | base64 -D | gzip -dc > out
@@ -83,16 +83,16 @@ ${W`eBKey} = (.("{0}{1}{2}" -f 'Ne','w-Objec','t') ("{2}{3}{4}{1}{0}" -f 'nt','b
 If ([IntPtr]::size -eq 8) { start-job { param($a) IEX $a } -RunAs32 -Argument $None | wait-job | Receive-Job } else { IEX $None }
 ```
 
-This Powershell script seems to do a lot but is actually quite simple:
+This PowerShell script seems to do a lot but is actually quite simple:
 
-* Create a variable named `None` that actually contains another Powershell
+* Create a variable named `None` that actually contains another PowerShell
   script
 * Invoke this script
 
 And regarding the so-called script:
 
 * Define a function `send_postie` (does not look important, let's ignore it)
-* Define a function `get_java`, that does some shaddy business (let's ignore it too)
+* Define a function `get_java`, that does some shady business (let's ignore it too)
 * Define a function `BxoriT` that looks much more interesting (array of bytes, 
   xor...) but also obfuscated (more on that later). This function takes a
   parameter that is called `key`.
@@ -100,7 +100,7 @@ And regarding the so-called script:
   string
 * Call `BxoriT` with `13` as parameter
 * Call `BxoriT` again, with `37` as parameter
-* Perform some more obfuscated business (at this point I stoped reading and
+* Perform some more obfuscated business (at this point I stopped reading and
   wanted to take a look at `BxoriT` first)
 
 The `BxoriT` function uses
@@ -151,7 +151,7 @@ for ($x = 0; $x -lt $BxoiT.Count; $x++) { $BxoiT[$x] = $BxoiT[$x]-BxoR$key };
 ```
 
 So it is a simple for-loop that iterates over `BxoiT` (the byte array created
-from the base64) and XOR each byte using the key passed as parameter to
+from the base64) and XORs each byte using the key passed as parameter to
 `BxoriT`. I did not get that immediately because of this part of the
 expression: `$BxoiT[$x]-BxoR$key`. I thought it was: `$BxoiT[$x] - BxoR$key`,
 which does not make any sense as `BxoR` would be an undefined name. If we
@@ -184,7 +184,7 @@ with open("source", "rb") as src_file:
         dest_file.write(result)
 ```
 
-The result is written in a file as it contains binary data. Providing that
+The result is written in a file as it contains binary data. Provided that
 the base64 is in a file called `source`:
 
 ```
@@ -227,5 +227,5 @@ Final flag: `dctf{L1ttl3_r3D-sh3llc0d3_th@t_1-c4n_dr0p}`.
 
 A few things learned from this challenge:
 
-* Simple Powershell scripts can most likely be emulated in a *NIX environment
+* Simple PowerShell scripts can most likely be emulated in a *NIX environment
 * Do not try to understand code that is not used at the end

--- a/src/content/posts/deloitte-superhero.md
+++ b/src/content/posts/deloitte-superhero.md
@@ -32,7 +32,7 @@ Nmap scan report for ec2-3-9-190-45.eu-west-2.compute.amazonaws.com (3.9.190.45)
 Nmap done: 1 IP address (1 host up) scanned in 1.27 seconds
 ```
 
-We notice something unusal: `EtherNetIP-1` on port `2222`. This is a fairly
+We notice something unusual: `EtherNetIP-1` on port `2222`. This is a fairly
 popular SSH port. Let's try:
 
 ```

--- a/src/content/posts/eslint-guide.md
+++ b/src/content/posts/eslint-guide.md
@@ -2,7 +2,7 @@
 title: ESLint configuration and best practices
 slug: eslint-guide
 date: 2020-01-23
-description: "Learn how to use and configure ESLint in order to keep your JavaScript codebase clean and consistent. We'll take a loot at different setups, including TypeScript and React."
+description: "Learn how to use and configure ESLint in order to keep your JavaScript codebase clean and consistent. We'll take a look at different setups, including TypeScript and React."
 ---
 
 🗨️ You can discuss this article [on Reddit](https://www.reddit.com/r/javascript/comments/etaj6h/eslint_configuration_and_best_practices/).
@@ -19,7 +19,7 @@ See this [update article](/eslint-parser-services).
 
 ***
 
-This post describes how I setup [ESLint](https://eslint.org/) in different
+This post describes how I set up [ESLint](https://eslint.org/) in different
 scenarios. We'll start with a simple plain JavaScript project and then we'll
 deal with TypeScript, and also React. The aim is to do the things *right* and
 avoid installing random packages or copy/pasting snippets of configuration until
@@ -42,7 +42,7 @@ look at the following pieces of documentation:
 -   [Airbnb CSS in JavaScript style guide](https://github.com/airbnb/javascript/tree/master/css-in-javascript)
 -   [Airbnb Sass style guide](https://github.com/airbnb/css)
 
-There are explanations for every settings. It is also a great starting point if
+There are explanations for every setting. It is also a great starting point if
 you wish to design your own configuration.
 
 **Summary**
@@ -67,7 +67,7 @@ appropriate.
 ## Why ESLint?
 
 There is no competing project to my knowledge. ESLint is highly configurable and
-well maintained. Most people or company who design JavaScript style guides
+well maintained. Most people or companies who design JavaScript style guides
 implement it for ESLint.
 
 A few alternatives I had the chance to try are:
@@ -86,7 +86,7 @@ A few alternatives I had the chance to try are:
     can totally extract the ESLint configuration it is using.
 
 -   [TSLint](https://palantir.github.io/tslint/) is a TypeScript linter
-    that used to be very popular. But is has been
+    that used to be very popular. But it has been
     [deprecated](https://github.com/palantir/tslint/issues/4534) and is
     being merged with ESLint. The exact situation is a bit vague but in
     reality, TypeScript linting is totally possible inside ESLint, with
@@ -115,7 +115,7 @@ It would make sense to install ESLint at the global level so that it could be
 invoked from anywhere. However, I prefer to install it at the project level for
 a few reasons:
 
--   Allows to have different versions of ESLint for different projects
+-   Allows us to have different versions of ESLint for different projects
 -   Does not *hide* the ESLint dependency. There is no reason not to make it
     explicit.
 -   Coworkers and automation tools (such as a CI) will install ESLint just like
@@ -153,7 +153,7 @@ command line arguments we are using and get a cleaner interface. In the
 }
 ```
 
-The `.` parameter allows to run ESLint in the current directory. It can now be
+The `.` parameter allows us to run ESLint in the current directory. It can now be
 invoked via the `lint` task:
 
 ```
@@ -222,7 +222,7 @@ A lot of companies such as
 [Airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb)
 or
 [Facebook](https://github.com/facebook/fbjs/tree/master/packages/eslint-config-fbjs-opensource)
-spend a lot of time maintaining configuration that are already widely adopted,
+spend a lot of time maintaining configurations that are already widely adopted,
 have sane defaults and are kept up to date.
 
 My favorite one is Airbnb's and this is the one we are going to use. Let's
@@ -237,7 +237,7 @@ package, which also includes configurations for React, React Hooks, etc. This is
 not necessary in our case, as we are dealing with a plain JavaScript project.
 
 Note that we are **not** using `npm` to install the package but
-`npx install-peerdeps`.This is because the configuration package has peer
+`npx install-peerdeps`. This is because the configuration package has peer
 dependencies. This is actually the case for most ESLint configuration packages
 as they usually depend on ESLint plugins, or even other configuration packages.
 
@@ -301,9 +301,9 @@ rules:
 Our settings override the configuration packages we are inheriting.
 
 The report also mentions the `--fix` option. It works really well when it comes
-to automatically fix simple problems such as indentation or missing semicolons.
+to automatically fixing simple problems such as indentation or missing semicolons.
 There is also `--fix-dry-run` which gives an overview of the fixes, without
-actually writing the filesystem.
+actually writing to the filesystem.
 
 For a plain JavaScript project, this is enough configuration for me. I try not
 to override Airbnb's rules as this configuration is super popular as it is and

--- a/src/content/posts/eslint-parser-services.md
+++ b/src/content/posts/eslint-parser-services.md
@@ -12,7 +12,7 @@ means that we won't have to deal with [this warning](https://github.com/iamturns
 
 However, if you followed my [ESLint guide](/eslint-guide), this update will most likely
 break your configuration. The reason is that two breaking changes were introduced
-in this `7.0.0` realease.
+in this `7.0.0` release.
 
 First, `@typescript-eslint/eslint-plugin` must be upgraded to `2.19.0`. For
 example:
@@ -26,8 +26,8 @@ in your ESLint configuration. The reason for that is that some new rules
 which require type information were introduced and they need to know where
 your `tsconfig.json` file is in order to work properly.
 
-I'm quite suprised that this attribute does not have `tsconfig.json` or, more
-explicitely, `./tsconfig.json` as a default but anyway, here is how to fix it
+I'm quite surprised that this attribute does not have `tsconfig.json` or, more
+explicitly, `./tsconfig.json` as a default but anyway, here is how to fix it
 in a YAML configuration:
 
 ```yaml
@@ -37,7 +37,7 @@ parserOptions:
 ```
 
 In case you don't already have a `tsconfig.json` file, here is how you can
-generate a *default* one, providing that `typescript` is already a local
+generate a *default* one, provided that `typescript` is already a local
 dependency of the project:
 
 ```

--- a/src/content/posts/hexpresso-fic.md
+++ b/src/content/posts/hexpresso-fic.md
@@ -6,8 +6,8 @@ date: "2019-12-19T00:00:00"
 
 The FIC (*Forum International de la Cybersécurité*) is an event that takes
 place in Lille, France every year. This year, the French CTF team [Hexpresso](https://www.hexpresso.fr/)
-organizes the CTF. These guys have a pretty strong high fun/low guessing
-policy so I thought I will compete with my friends from Team Ropkek.
+organized the CTF. These guys have a pretty strong high fun/low guessing
+policy so I thought I would compete with my friends from Team Ropkek.
 
 ![Hopes](/assets/hexpresso-fic-quals/intro/hopes.png)
 
@@ -48,7 +48,7 @@ FINAL   -> [uniq hit : 16]
 +----------------------------------------------------------------------------+
 ```
 
-Well, technically, XeR was first but he won't compete the finals and I want
+Well, technically, XeR was first but he won't compete in the finals and I want
 to flex.
 
 Here are my writeups:
@@ -66,4 +66,4 @@ challenge of this qualification round), please take a look at
 written by my teammate Shiro.
 
 I'm excited for the finals. The other teams look very musclées so I'm scared
-but its ok.
+but it's ok.

--- a/src/content/posts/hexpresso-step1.md
+++ b/src/content/posts/hexpresso-step1.md
@@ -52,7 +52,7 @@ This line is important:
 if (u_u.charCodeAt(i) + flag.charCodeAt(i) + i * 42 != game[i]) {
 ```
 
-Its a simple equation (pseudocode):
+It's a simple equation (pseudocode):
 
 ```javascript
 u_u[i] + flag[i] + i * 42 = game[i]

--- a/src/content/posts/hexpresso-step2.md
+++ b/src/content/posts/hexpresso-step2.md
@@ -11,8 +11,8 @@ The second step is some network forensics.
 We are given a PCAP file. It is not too big, we can clearly observe three
 events (all the addresses are on `172.16.42.0`):
 
-* `.99` requests `/index.html` to `.222` (does not matter for the challenge)
-* `.99` requests `/dnstunnel.py` to `.222`
+* `.99` requests `/index.html` from `.222` (does not matter for the challenge)
+* `.99` requests `/dnstunnel.py` from `.222`
 * `.99` performs dozens of DNS queries
 
 Here is the Python script `dnstunnel.py`:
@@ -92,14 +92,14 @@ while cursor < len(data):
 Please, take a look at the comments on the script.
 
 We can understand that some secret payload has been sent using the DNS
-exfiltration technique. Its very simple: you just make a bunch of DNS
+exfiltration technique. It's very simple: you just make a bunch of DNS
 queries, embedding the data in the domain that is queried.
 
 The only real constraint of this technique is that the data has to be pure
 plaintext (as far as I know?) so you need some kind of encoding. The base64
 is often chosen but here it is base16.
 
-There is also a XOR operation... Each DNS query has its own key but really,
+There is also an XOR operation... Each DNS query has its own key but really,
 it is no big deal as the key is sent alongside the cipher.
 
 We will talk a bit more about the redundancy mechanism later. For now, we

--- a/src/content/posts/hexpresso-step3.md
+++ b/src/content/posts/hexpresso-step3.md
@@ -25,7 +25,7 @@ bruteforce. The combination of
 [Dislocker](https://wreckedsecurity.com/encryption-and-data-protection/brute-force-dictionary-attack-against-bitlocker/)
 and `rockyou.txt` reveals the password: `password`.
 
-Dislocker also allows to mount the volume and retrieve its files. Let's open
+Dislocker also allows us to mount the volume and retrieve its files. Let's open
 `flag.txt`:
 
 ```

--- a/src/content/posts/hexpresso-step4.md
+++ b/src/content/posts/hexpresso-step4.md
@@ -35,12 +35,12 @@ We now know that `main` is `FUN_00101570`:
 
 ![Encrypt File](/assets/hexpresso-fic-quals/step4/encrypt_file.png)
 
-This function retrieves the current time via `time(NULL)` and call the actual
+This function retrieves the current time via `time(NULL)` and calls the actual
 encryption routine (`FUN_00101220`). Let's see:
 
 ![Routine](/assets/hexpresso-fic-quals/step4/routine.png)
 
-Nothing special, it is a basically a XOR. The key is generated from the
+Nothing special, it is basically a XOR. The key is generated from the
 current time and the name of the file to be encrypted.
 
 Let's recap what we know:

--- a/src/content/posts/hexpresso-step5.md
+++ b/src/content/posts/hexpresso-step5.md
@@ -8,7 +8,7 @@ The fifth step is a Python jail that we must escape.
 
 ![Introduction](/assets/hexpresso-fic-quals/step5/intro.png)
 
-We are provided a few files allowing to connect to the challenge:
+We are provided a few files allowing us to connect to the challenge:
 
 ```
 $ socat stdio openssl-connect:ctf.hexpresso.fr:2323,cert=client.pem,cafile=server.crt,verify=0
@@ -43,7 +43,7 @@ so we are in a Python 3.6 runtime at least
 * Our input is put into single quotes and forwarded to `eval`
 * We are in a function `get_input`
 * `get_input` is called in main
-* There is a `flag` variable in the `main` function that looks to hold the flag
+* There is a `flag` variable in the `main` function that seems to hold the flag
 
 We can inject Python using a standard closing/comment payload such as:
 
@@ -59,7 +59,7 @@ In that example, the following is evaluated:
 'vroum' and print('Hello') #'
 ```
 
-As `'vroum'` is a truthy, the other side of the `and` gets to be evaluated
+As `'vroum'` is truthy, the other side of the `and` gets to be evaluated
 and our `print` is executed.
 
 I used [inspect](https://docs.python.org/3/library/inspect.html) in order
@@ -96,7 +96,7 @@ def get_flag():
     return flag
 ```
 
-Too bad for us... The flag is retrieved and then emmediately removed
+Too bad for us... The flag is retrieved and then immediately removed
 from the environment at the start of the script. We'll have to go back a couple
 of scopes in order to reach the `flag` variable and print its content.
 

--- a/src/content/posts/hexpresso-step6.md
+++ b/src/content/posts/hexpresso-step6.md
@@ -4,7 +4,7 @@ slug: hexpresso-fic-6
 date: "2019-12-20T06:00:00"
 ---
 
-The sixth step is a WEB application that allows us to fetch an URL.
+The sixth step is a web application that allows us to fetch a URL.
 
 ![Introduction](/assets/hexpresso-fic-quals/step6/intro.png)
 
@@ -26,13 +26,13 @@ itself, right? This challenge really looks like a standard SSRF anyways...
 ![Not so easy](/assets/hexpresso-fic-quals/step6/not_so_easy.png)
 
 *Note: we must add a GET parameter because the script appends
-`:80/` at the end of the URL. We could deal with it but its more convenient
+`:80/` at the end of the URL. We could deal with it but it's more convenient
 to totally absorb it.*
 
 It seems that `0.0.0.0` is reachable. We should now be coming from `127.0.0.1`
 but there is something else. We are missing the `GOSESSION` cookie.
 
-I tried to trick the applicaion for some time but the problem is clear: we
+I tried to trick the application for some time but the problem is clear: we
 have to control the body of the query that the URL fetcher performs in order to
 add the cookie.
 
@@ -40,18 +40,18 @@ At this point, I was very sad and did not know what to do. I was about to
 give up when my teammate [Plean](https://twitter.com/plean702) sent me
 [this link](https://github.com/golang/go/issues/30794).
 
-[CVE-2019-9741](https://nvd.nist.gov/vuln/detail/CVE-2019-9741) is a CRFL
+[CVE-2019-9741](https://nvd.nist.gov/vuln/detail/CVE-2019-9741) is a CRLF
 injection, in the `net/http` package of Go (version 1.11). It is exactly
-what we need as it allows to write the body of the query.
+what we need as it allows us to write the body of the query.
 
-I tweaked the example payload of the GitHub (see the link above) issue and
+I tweaked the example payload of the GitHub issue (see the link above) and
 came up with this:
 
 ```
 0.0.0.0/secret?b%3d%20HTTP/1.1%0d%0aCookie:%20GOSESSION%3dabc
 ```
 
-A bit more readble:
+A bit more readable:
 
 ```
 0.0.0.0/secret?b= HTTP/1.1\r

--- a/src/content/posts/js-minimum-time.md
+++ b/src/content/posts/js-minimum-time.md
@@ -4,9 +4,9 @@ slug: js-minimum-time
 date: 2018-12-10
 ---
 
-Un ami m'a demandé si il était possible de forcer une fonction asynchrone à
+Un ami m'a demandé s'il était possible de forcer une fonction asynchrone à
 mettre au moins une certaine période de temps à s'exécuter. Par fonction
-asynchrone, j'entends fonction retounant une `Promise`.
+asynchrone, j'entends fonction retournant une `Promise`.
 
 Commençons par écrire une fonction asynchrone de test :
 
@@ -25,7 +25,7 @@ compris entre :
 
 On va wrapper l'appel à la fonction `request` pour faire notre cuisine.
 
-La durée maximale se gêre facilement, c'est simplement un `.then()`/`.catch()`
+La durée maximale se gère facilement, c'est simplement un `.then()`/`.catch()`
 classique :
 
 ```js

--- a/src/content/posts/lehack-alphajet.md
+++ b/src/content/posts/lehack-alphajet.md
@@ -60,7 +60,7 @@ The rest of the file is just a list of numbers between `0` and `255`. Each one
 of these numbers is a pixel of the image.
 
 The scripts presented in this article take advantage of the fact that the image
-we are given only has one pixel per line. It is not the case of most PGM files.
+we are given only has one pixel per line. It is not the case for most PGM files.
 
 ```
 $ sed -n 4,15p alphajet.pgm
@@ -82,17 +82,17 @@ $ sed -n 4,15p alphajet.pgm
 ## Solving the task
 
 I did not manage to solve the task during the CTF even though I spent some time
-playing with the file (see the end of the article for more). On the day after,
-a friend told me that some pixels looked off and that is could be a LSB.
+playing with the file (see the end of the article for more). The day after,
+a friend told me that some pixels looked off and that it could be an LSB.
 
-*Note: LSB stands for Least Significant Bit. It is a very common steganograpy
+*Note: LSB stands for Least Significant Bit. It is a very common steganography
 technique. Please, see this
 [great article](https://www.boiteaklou.fr/Steganography-Least-Significant-Bit.html) if
 you want to know more.*
 
-After some scripting, I find that the LSB is always set, which does not
-allow any room for hidden data. So I think I would try to extract the most
-significant bits (MSB) instead. Here the Python script I use:
+After some scripting, I found that the LSB is always set, which does not
+allow any room for hidden data. So I thought I would try to extract the most
+significant bits (MSB) instead. Here is the Python script I used:
 
 ```python
 #! /usr/bin/env python3
@@ -236,7 +236,7 @@ It looks like the image is fading in:
 
 ![Threshold](/assets/alphajet/threshold.gif)
 
-It looks great, although I can't think about any practical use for this... :')
+It looks great, although I can't think of any practical use for this... :')
 
 **The layers**
 
@@ -245,8 +245,8 @@ with such a small color contrast that one could not see it with the naked eye.
 So I thought I would extract all the "layers" of the image. A layer being all
 the pixels of a certain color.
 
-According to the max value parameter of the picture, there is at most 254
-layers. In practice, there is actually 255 (1 to 255).
+According to the max value parameter of the picture, there are at most 254
+layers. In practice, there are actually 255 (1 to 255).
 
 Here is a script to extract such layers:
 
@@ -313,7 +313,7 @@ if __name__ == "__main__":
   main()
 ```
 
-The tolerance allows to grab the adjacent colors and get different results.
+The tolerance allows us to grab the adjacent colors and get different results.
 With tolerance 1:
 
 ![Tolerance 1](/assets/alphajet/layers_1.gif)
@@ -328,8 +328,8 @@ With tolerance 70:
 
 **Negative mode**
 
-We can create a negative version of the image by substracting each pixel value
-to the maximum one:
+We can create a negative version of the image by subtracting each pixel value
+from the maximum one:
 
 ```python
 #! /usr/bin/env python3

--- a/src/content/posts/macos-restic-b2.md
+++ b/src/content/posts/macos-restic-b2.md
@@ -46,7 +46,7 @@ was aiming for, at least).
 
 This post walks the setup top to bottom. We start with the building blocks and
 run a backup by hand. Then we wire it into launchd so it runs every night.
-After that, we work on some _polish_: notifications, cosmetics...And finally,
+After that, we work on some _polish_: notifications, cosmetics... And finally,
 the repo layout. The code is on GitHub at
 [lucas-santoni/macos-backup-restic-b2](https://github.com/lucas-santoni/macos-backup-restic-b2).
 
@@ -662,7 +662,7 @@ yet. We build that next!
 
 ### The `.app` bundle, AMFI, and codesigning
 
-This is the most goofy-looking 🤪 part of the setup. A backup script ending up
+This is the goofiest-looking 🤪 part of the setup. A backup script ending up
 inside an `.app` bundle, codesigned, feels disproportionate to the task. I
 tried to avoid this as much as possible but after a lot of iterations, I
 actually don't think there is a way around it.
@@ -934,7 +934,7 @@ forget at 03:00. On a Mac that's awake at 02:30, backup finishes well under 30
 minutes and the schedule is fine. With DarkWake-fragmented execution, backup
 might still be running (suspended, mostly) at 03:00. Both restic and
 resticprofile use locks but the default behavior is "fail immediately if
-locked" which is not ideal if the laptop is asleep or if a backup takes
+locked", which is not ideal if the laptop is asleep or if a backup takes
 longer than usual for whatever reason.
 
 The fix is two directives, as there are two locks:

--- a/src/content/posts/missing-pelican-plugins-guide.md
+++ b/src/content/posts/missing-pelican-plugins-guide.md
@@ -10,11 +10,11 @@ powers this blog. It is written in Python and I like it for its simplicity
 and sane defaults.
 
 Pelican's functionalities can be extended by writing **plugins**. These
-pieces of code, also written in Python, allow to perform actions at the
+pieces of code, also written in Python, allow us to perform actions at the
 different stages of the build process.
 
 The [documentation](http://docs.getpelican.com/en/latest/plugins.html) does
-not say much about plugins development. The aim of this post is to provide
+not say much about plugin development. The aim of this post is to provide
 enough information so that you could write your own plugins.
 
 ## Install plugins
@@ -52,7 +52,7 @@ look like this:
 1. Scan for all the posts' paths
 2. Read their content
 3. Transform their content to HTML
-3. Write the HTML to the output directory
+4. Write the HTML to the output directory
 
 Now, let's imagine that, for each of these steps, you could have a chance
 to run a function. On step 2, the function could look like this:
@@ -69,7 +69,7 @@ is able to read. Moreover, any modification that you do to the `content`
 object that is received as parameter would be preserved for the rest of the
 build process.
 
-Such function is usually called a *callback*, or a *hook*. It is called
+Such a function is usually called a *callback*, or a *hook*. It is called
 automatically when a corresponding *event* happens in the build process. But
 how do we associate an event and a hook function?
 
@@ -98,7 +98,7 @@ create a custom generator (keep reading to know more).
 **`article_generator_write_article`**
 
 Happens before writing each article. You get the generator instance for the
-article being processed, and the actual article (including its metadatas) as
+article being processed, and the actual article (including its metadata) as
 parameters. You could write a plugin to calculate the read time of an article
 here.
 
@@ -132,7 +132,7 @@ description:
 The parameters we must receive in our callback are named `path` and
 `context`. There is no type definition in the documentation to my knowledge
 so you will have to explore Pelican's source code or read other people's
-module in order to understand the actual types of these variables. Of course,
+modules in order to understand the actual types of these variables. Of course,
 you can also use Python's introspection with `dir` or `.keys()` while writing
 the module.
 
@@ -170,7 +170,7 @@ Let's run it:
 
 ![Failed run](/assets/pelican-plugins/failed.png)
 
-Wups! Our plugin actually is a Python package so Pelican imports it and try
+Wups! Our plugin actually is a Python package so Pelican imports it and tries
 to call its `register` function. In order to expose it, let's create the
 `plugins/toy/__init__.py` file with the following content:
 
@@ -184,8 +184,8 @@ Now it works:
 
 There is one problem we can immediately observe: our plugin does not make any
 difference between articles (what we are interested in), and other document
-types (such as pages). How can we know what is the type of the document being
-processed? The `context` can help.
+types (such as pages). How can we know what the type of the document being
+processed is? The `context` can help.
 
 Indeed, if the document being processed is an article, context would have an
 `article` key. Otherwise, it would not. Let's update our `run` function:
@@ -242,39 +242,39 @@ is divided between different entities. They are the readers, the generators,
 and the writers.
 
 A **reader** is responsible for reading the raw files from the disk. For each
-file, it parses its metadatas and transforms its content into the desired
+file, it parses its metadata and transforms its content into the desired
 target output format. Pelican ships with a bunch of readers and the most used
 one probably is the Markdown one. [Click here to see how it looks.](https://github.com/getpelican/pelican/blob/master/pelican/readers.py#L283)
-Beside its format, a reader does not have any clue about the document it is
+Besides its format, a reader does not have any clue about the document it is
 working with. A generator has.
 
 A **generator** receives inputs (including the readers' outputs) and transforms
 them into actual pages for your sites. Articles, pages, categories, tags,
 archives... It all happens here. The generator organizes the data that it got
 from the readers and updates the `context`. [Click here to take a look at the generator for the articles](https://github.com/getpelican/pelican/blob/master/pelican/generators.py#L277).
-When he is finished, the generator calls a writer.
+When it is finished, the generator calls a writer.
 
-A **writer**, as its name suggests, writes the output directory and transform the
+A **writer**, as its name suggests, writes to the output directory and transforms the
 in-memory documents that the generator crafted into actual files that
-ultimately constitutes your website. Pelican ships with a single writer,
+ultimately constitute your website. Pelican ships with a single writer,
 [see it here](https://github.com/getpelican/pelican/blob/master/pelican/writers.py#L19).
 
 Pelican's plugin API allows you to write custom readers, generators, and
 writers.
 
-Writing a **custom reader** allows you to integrate a new source format to
+Writing a **custom reader** allows you to integrate a new source format into
 Pelican. For example, you could be very fond of the [AsciiDoc](http://asciidoc.org/) syntax
 and develop a reader plugin so that you can write your posts in AsciiDoc.
-This is the perfect use case and such module actually [already exist](https://github.com/getpelican/pelican-plugins/tree/master/asciidoc_reader).
+This is the perfect use case and such a module actually [already exists](https://github.com/getpelican/pelican-plugins/tree/master/asciidoc_reader).
 Of course, the parsing can be delegated to a module. You are writing Python
 after all!
 
 Writing a **custom generator** is great if you want to create an entirely
-custom page for you site. A lot can be done by tweaking your theme and its
+custom page for your site. A lot can be done by tweaking your theme and its
 templates but sometimes, you feel that a generator is necessary, especially
 if you need to implement a lot of logic. See the next section to know more.
 
-Writing a **custom writer** is not a very common task. Most plugins
+Writing a **custom writer** is not a very common task. Most plugin
 developers end up doing the writing part directly into the generator, which
 does not seem to be a bad practice.
 
@@ -282,7 +282,7 @@ does not seem to be a bad practice.
 
 Let's write another plugin. This one is going to be a custom generator. Our
 aim is to generate a JavaScript "index" for our site. Basically, I want to
-have some kind of *introspection* that allows me to write client side
+have some kind of *introspection* that allows me to write client-side
 code like this:
 
 ```js
@@ -296,15 +296,15 @@ const results = sorted.slice(0, 5);
 
 I use this piece of code in my [404](/pelican-plugin) (note the missing *s*
 in the link's URL) page in order to automatically fix some broken links. I
-have a complete article coming on this topic but here was this script does:
+have a complete article coming on this topic but here is what this script does:
 
 1. Retrieve the slug that the user requested
 2. For each page of the site, compute the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between
-  its slug, and the one the user required
+  its slug, and the one the user requested
 3. Sort the results
 4. Extract the top 5 results, at most
 
-How does this script now about all the slugs of my site and their associated
+How does this script know about all the slugs of my site and their associated
 titles? What is this `API` object? Here is how it looks:
 
 ![API output](/assets/pelican-plugins/api.png)
@@ -325,7 +325,7 @@ def register():
 ```
 
 The `get_generators` function will be called when Pelican collects the
-generator and `APIGenerator` will be returned. This class is a Pelican
+generators and `APIGenerator` will be returned. This class is a Pelican
 generator. What does it look like?
 
 ```python
@@ -349,8 +349,8 @@ The constructor receives quite a few parameters. Here they are:
 * `settings` (dictionary), all the global site settings. Mostly parsed from
   `pelicanconf.py`.
 * `path` (string), absolute path to the content directory.
-* `theme` (string) absolute path to active theme directory.
-* `output_path` (string) absolute path to the output directory.
+* `theme` (string), absolute path to active theme directory.
+* `output_path` (string), absolute path to the output directory.
 
 The two parameters we are interested in are `context`, in order to go through
 the articles and pages, and `output_path`, in order to know where to write
@@ -369,7 +369,7 @@ other module that was based on the API, we would surely do it though.
 
 Finally, let's define the `generate_output` method. Note that we don't use
 the `writer` that we get as a parameter as it is mostly made for the
-articles/pages generators and use templates. In our case, it is much simpler
+articles/pages generators and uses templates. In our case, it is much simpler
 to directly implement the writing logic.
 
 ```python
@@ -420,9 +420,9 @@ Our generator is now complete!
 
 ## Wrapping up
 
-This the end of this guide. You might want to take at look at [this series](http://adamcot.com/posts/2018/02/building-pelican-plugins-i/)
+This is the end of this guide. You might want to take a look at [this series](http://adamcot.com/posts/2018/02/building-pelican-plugins-i/)
 that goes through the development of a teaser image plugin next.
 
 The best learning resource for Pelican modules definitely is the Pelican source
 code itself. It is totally readable and is always up to date. Reading other
-people's modules also help a ton.
+people's modules also helps a ton.

--- a/src/content/posts/pingouin-epitech.md
+++ b/src/content/posts/pingouin-epitech.md
@@ -24,7 +24,7 @@ sélectionnés pour le semestre courant. En première année, les projets sont �
 95% du C.
 
 Beaucoup d'étudiants n'ont pas fait de C avant leur entrée en première année
-et les lâcher dans la nature serait assez aberrant quand on connait le prix
+et les lâcher dans la nature serait assez aberrant quand on connaît le prix
 de l'école. Ainsi, des "labs" ont été créés. Pour la programmation, ils sont
 au nombre de deux :
 
@@ -54,18 +54,18 @@ ceux qu'on appelle les pingouins (lab, banquise, pingouin ? Ouais, ouais...).
 
 Je ne sais pas vraiment pourquoi et comment le LabAnquise est apparu à Epitech
 mais dans les faits, c'est un lab existant sur Paris et dans certaines régions,
-**par des premières années, pour des première années**.
+**par des premières années, pour des premières années**.
 
 L'objectif du lab et de tous ses pingouins est d'apporter **du soutien en
 langage C** aux étudiants de leur promo.
 
 Vers février, les pingouins de l'année passée organisent des **entretiens**
 pour les candidats volontaires afin de repérer **des étudiants solides, déjà à
-l'aise dans leur cursus**, qui pourraient faire des bons pingouins pour l'année
+l'aise dans leur cursus**, qui pourraient faire de bons pingouins pour l'année
 en cours.
 
 **Une vingtaine** d'étudiants (pour **une promo d'environ 450** sur Paris) en
-sortent pingouins. S'en suit une petite pizza party au cours de laquelle on
+sortent pingouins. S'ensuit une petite pizza party au cours de laquelle on
 élit le chef pingouin (rapidement surnommé "papa pingouin") et le lab peut
 démarrer ses activités.
 
@@ -73,7 +73,7 @@ démarrer ses activités.
 
 En discutant avec les équipes des années passées, je me suis rendu compte que
 ce lab était assez inactif depuis plusieurs années. Quelques petites sessions
-de soutien de temps à autres, pas vraiment préparées. J'ai tout de suite trouvé
+de soutien de temps à autre, pas vraiment préparées. J'ai tout de suite trouvé
 ça dommage. En effet, j'ai remarqué que parmi les pingouins, beaucoup avaient
 déjà pris **l'habitude d'aider les autres** et jouissaient d'une certaine
 **position de leaders** dans leurs salles respectives. Le LabAnquise était
@@ -89,8 +89,8 @@ qu'ils ont le potentiel de transmettre est tout simplement énorme**.
 **Le LabAnquise n'a pas vraiment de légitimité. Il n'a pas de statut, pas de
 budget, n'est pas représenté lors des réunions liées à la pédagogie de
 l'école**. Or, je pense que les pingouins ont besoin d'une certaine légitimité
-pour mener à bien leur travaux. Les étudiants à qui l'on s'adresse ne doivent
-pas être méfiants à notre égard. Au contraire, **si ils éprouvent de
+pour mener à bien leurs travaux. Les étudiants à qui l'on s'adresse ne doivent
+pas être méfiants à notre égard. Au contraire, **s'ils éprouvent de
 l'admiration ou du respect pour les pingouins, ils seront beaucoup plus enclins
 à écouter ce qu'ils ont à leur dire et à reproduire ce qu'ils leur montrent**.
 Je pense **qu'un étudiant doit envier un pingouin**, envier son statut et que
@@ -101,7 +101,7 @@ sweats Epitech avec logo et pseudonymes (merci encore à [Main
 Gauche](https://www.main-gauche.com/) qu'on a littéralement harcelé pour avoir
 des réductions), module sur l'intranet de l'école pour nos activités,
 utilisation récurrente d'une même salle pour donner l'illusion qu'on a
-des locaux... Nous nous sommes rapidement ancré dans le paysage d'Epitech
+des locaux... Nous nous sommes rapidement ancrés dans le paysage d'Epitech
 Paris et les étudiants ont vite pris l'habitude de venir solliciter
 l'aide des pingouins.
 
@@ -125,7 +125,7 @@ l'année.
 
 ![Statistiques fondamentaux](/assets/pingouins/graph_basic.png)
 
-*Lecture : 36% de la population étudiée ne se sent alors pas l'aise avec la
+*Lecture : 36% de la population étudiée ne se sent alors pas à l'aise avec la
 notion de tableau en langage C.*
 
 Nous avons ici les cinq fondamentaux étudiés en piscine. Sans surprise, **les
@@ -136,7 +136,7 @@ tableaux, certes).
 J'imagine que les étudiants ayant répondu à ce sondage voulaient **indiquer aux
 pingouins qu'ils ne devaient pas hésiter à faire des sujets très accessibles,
 reprenant même les notions les plus élémentaires**. L'équipe
-pédagogique nous as confirmé que même plusieurs mois après le début de l'année,
+pédagogique nous a confirmé que même plusieurs mois après le début de l'année,
 il existe encore une grosse population d'étudiants en difficulté qui apprécie
 ce genre de contenu.
 
@@ -199,7 +199,7 @@ telle que transmise par l'équipe pédagogique et le LabAstek/Koalab :
   - Ne jamais perdre patience
   - Ne jamais affirmer une chose dont on doute soi-même
 
-Le contact avec les étudiants à été excellent tout au long de l'année et nous
+Le contact avec les étudiants a été excellent tout au long de l'année et nous
 avons eu des retours très positifs sur chacun de nos ateliers. **Les membres de
 l'équipe pédagogique ont également été de supers interlocuteurs qui nous ont
 fait confiance.**
@@ -208,7 +208,7 @@ fait confiance.**
 
 La position de chef du LabAnquise est assez amusante. **C'est un chef
 illégitime à la tête d'un lab illégitime**. Après tout, c'est un première année
-comme les autres, pourquoi est ce qu'ils le respecteraient ?
+comme les autres, pourquoi est-ce qu'ils le respecteraient ?
 
 Le travail du chef pingouin est de s'assurer que les activités se déroulent
 sans accroc et qu'il n'existe pas de tension entre les pingouins ou avec les
@@ -217,7 +217,7 @@ sans accroc et qu'il n'existe pas de tension entre les pingouins ou avec les
 Les membres du LabAnquise n'ont pas choisi de travailler ensemble, certains ne
 s'apprécient pas. **Ces tensions ne doivent pas sortir du lab car elles
 entraînent une perte importante de crédibilité.** Les tensions avec les
-étudiants sont tout aussi inaceptables, il s'agit d'une **pure perte de
+étudiants sont tout aussi inacceptables, il s'agit d'une **pure perte de
 temps**, pour eux comme pour nous.
 
 Le titre de chef pingouin ne confère aucun pouvoir pouvant renforcer son
@@ -240,7 +240,7 @@ d'être une rockstar de C pour bien représenter le LabAnquise. **Les étudiants
 sélectionnés sont à l'aise avec les concepts étudiés en première année et ont
 prouvé lors de l'entretien qu'ils sont capables de les exposer clairement.** On
 retrouve souvent quelques pingouins chez les asteks juniors de l'année
-suivante. Qu'est ce qui sépare les pingouins qu'ils étaient des asteks qu'ils
+suivante. Qu'est-ce qui sépare les pingouins qu'ils étaient des asteks qu'ils
 sont devenus ? 6 mois de stage pendant lesquels ils n'ont sûrement pas fait de
 C ? **Les bons étudiants se démarquent très très vite et autant qu'ils
 soient au plus vite mobilisés.**
@@ -252,7 +252,7 @@ formation en bonne et due forme ferait d'eux des asteks, ce qu'ils ne sont pas.
 Beaucoup d'étudiants n'osent pas franchir les portes de la pédagogie et
 interpeller un astek en première année. Ces étudiants peuvent toujours se
 tourner vers un pingouin, **un type de leur salle qu'ils croisent tous les
-jours** depuis le début de l'année et avec qui ils ont surement déjà échangé.
+jours** depuis le début de l'année et avec qui ils ont sûrement déjà échangé.
 
 Certes, cela pose des problèmes. Les pingouins font des erreurs : ils disent
 des choses fausses, ils donnent des réponses trop rapidement... **Ces problèmes
@@ -275,6 +275,6 @@ leur mission ne leur rapporte pour ainsi dire rien est gage de leur motivation.
 
 Cette dernière partie a certainement des allures de droit de réponse. Je pense
 en effet que le LabAnquise a un rôle à jouer dans l'école et que l'énergie
-qu'on emploie à le critiquer serait mieux investit à l'améliorer.
+qu'on emploie à le critiquer serait mieux investie à l'améliorer.
 
 _Merci à Clara pour son aide._

--- a/src/content/posts/piscine-poc-2019.md
+++ b/src/content/posts/piscine-poc-2019.md
@@ -1,5 +1,5 @@
 ---
-title: "[FRENCH] Piscine Securité POC 2019"
+title: "[FRENCH] Piscine Sécurité POC 2019"
 slug: piscine-poc-2019
 date: 2019-02-13
 ---

--- a/src/content/posts/prisma-graphql-api.md
+++ b/src/content/posts/prisma-graphql-api.md
@@ -1,8 +1,8 @@
 ---
-title: Build production grade API with Prisma and GraphQL
+title: Build a production-grade API with Prisma and GraphQL
 slug: prisma-graphql-api
 date: 2020-07-30
-description: Learn how to build a production ready GraphQL API endpoint using Prisma. This tutorial is aimed at beginners and covers all the basics.
+description: Learn how to build a production-ready GraphQL API endpoint using Prisma. This tutorial is aimed at beginners and covers all the basics.
 cover: /assets/prisma/cover.png
 ---
 
@@ -24,7 +24,7 @@ the past few months. As they
 I thought it could be interesting to share my experience.
 
 In this article, I will show you how and why you should build your next
-GraphQL API with Prisma. For demonstration purpose we will build a simple API
+GraphQL API with Prisma. For demonstration purposes we will build a simple API
 that could be used for a basic blog application. The complete code can be
 found in [this GitHub repository](https://github.com/gabrielcolson/blog-prisma-graphql).
 
@@ -41,14 +41,14 @@ In order to follow along in the best conditions, here are a few requirements:
 
 ## Architecture
 
-In a typical web application, the code can usually be split in 3 distinct
+In a typical web application, the code can usually be split into 3 distinct
 layers:
 
 ![Web Application Layers](/assets/prisma/layers-schema.png)
 
 **The data layer**
 
-This is the code responsible to shape, persist and access the data consumed
+This is the code responsible for shaping, persisting and accessing the data consumed
 by the application. In the case of our app, it will describe the shape of a
 `Post`, a `User`, etc. It will also provide basic CRUD (**C**reate, **R**ead,
 **U**pdate, **D**elete) operations, so we can manipulate and persist the data
@@ -69,7 +69,7 @@ REST, or any other endpoint.
 
 **Prisma**
 
-There is usually 3 ways to interact with a database in Node.js:
+There are usually 3 ways to interact with a database in Node.js:
 
 1. Raw SQL written in a string. You have absolutely no type safety,
    no auto completion, and no syntax highlighting. It is hard to write
@@ -214,7 +214,7 @@ docker run                        \
   postgres
 ```
 
-This command starts a container running PostgreSQL and listen to the port 5432.
+This command starts a container running PostgreSQL and listens on port 5432.
 
 All we have to do now is to replace the content of the `prisma/.env` file
 with this:
@@ -306,7 +306,7 @@ resources defined in the `schema.prisma`.
 npx prisma generate
 ```
 
-If everything went good, we should be able to use it in our `src/index.ts` file:
+If everything went well, we should be able to use it in our `src/index.ts` file:
 
 ```typescript
 import { PrismaClient } from '@prisma/client';
@@ -345,7 +345,7 @@ async function main() {
 main().finally(() => prisma.disconnect());
 ```
 
-This little script demonstrate how easy it is to use the Prisma Client. The
+This little script demonstrates how easy it is to use the Prisma Client. The
 code speaks for itself: we create a user, we create a post linked to this
 user, and we fetch the post including its author. I strongly encourage you to
 write this code by yourself on your favorite editor, so you can appreciate
@@ -422,7 +422,7 @@ export default schema;
 
 Nexus will generate 2 different artifacts in development mode:
 
-- A GraphQL schema, it gives us a clear view of how our final API looks like
+- A GraphQL schema, it gives us a clear view of what our final API looks like
 - The Nexus types, it ensures type safety in our resolvers.
 
 To generate those files, we can add a script to our `package.json`:
@@ -602,7 +602,7 @@ server.listen().then(({ url }) => {
 ```
 
 Run it with `npm start` and go to http://localhost:4000/. From there you
-access the GraphQL Playground where we can play with our schema and make sure
+can access the GraphQL Playground where we can play with our schema and make sure
 everything works as expected.
 
 ![Prisma GraphQL Playground](/assets/prisma/graphql-playground.png)
@@ -678,7 +678,7 @@ export const UserQuery = extendType({
 The thing is that the `ctx` parameter is still typed as `any`. We said
 earlier that the biggest advantage of `@nexus/schema` was to have fully typed
 resolvers and this doesn't seem just right. The reason is that we didn't
-didn't tell Nexus to use our `Context` interface as our context type. In
+tell Nexus to use our `Context` interface as our context type. In
 order to do so, we have to add some configuration to `makeSchema`:
 
 ```javascript
@@ -701,7 +701,7 @@ You can now run `npm run generate` and see that our context is now correctly
 typed.
 
 Our GraphQL schema is now complete and fully typed! You can check the final
-version in the Github repository.
+version in the GitHub repository.
 
 ## The Logic Layer
 
@@ -713,7 +713,7 @@ To do that, I usually add a `services` module which contains all the
 functions I need in my resolvers. We could write this logic directly inside
 the resolvers but as the application grows, it will quickly become
 unmaintainable. Extracting these functions defines a clear separation of
-concerns and allow you to reuse some logic without duplication.
+concerns and allows you to reuse some logic without duplication.
 
 Here is how I implemented it for `User`:
 

--- a/src/content/posts/react-ts-cheatsheet.md
+++ b/src/content/posts/react-ts-cheatsheet.md
@@ -7,7 +7,7 @@ date: 2019-11-05
 Here is the
 [ESLint configuration](https://gist.github.com/Geospace/2a5fdbe7054afc3d210f60f12c5a5b03)
 I'm using. TypeScript (TS) is about actually putting types so the use of `any`,
-missing parameter types and missing return function types are forbidden.
+missing parameter types and missing function return types are forbidden.
 
 I'm using Create React App, with the following packages:
 
@@ -18,7 +18,7 @@ I'm using Create React App, with the following packages:
 ```
 
 
-## Function component, without logic nor props
+## Function component, with neither logic nor props
 
 This is the simplest case. Our component is a function that doesn't take
 anything and only returns a block of JSX.
@@ -83,10 +83,10 @@ const Component: React.FunctionComponent<Props> = ({ message }: Props): JSX.Elem
 );
 ```
 
-Because the configuration I use requires to annotate all the parameters and
+Because the configuration I use requires me to annotate all the parameters and
 return values, **the type signature is now duplicated**. Anyway, I think it's
 better to put the annotations on the left and let the compiler deduce the
-type on the right hand side. Moreover, these type names may change in the future
+type on the right-hand side. Moreover, these type names may change in the future
 so I will avoid **tying my code** to them.
 
 The names `React.SFC` (Stateless Function(al ?) Component) and
@@ -154,9 +154,9 @@ class Component extends React.Component<Props> {
 ```
 
 
-## Dealing with Higher Order Components
+## Dealing with Higher-Order Components
 
-An Higher Order Component (HOC) is all about injecting props into a component
+A Higher-Order Component (HOC) is all about injecting props into a component
 so we will have to add a few annotations. Here is an example with
 [React Router](https://reacttraining.com/react-router/web/guides/quick-start):
 
@@ -209,7 +209,7 @@ class Component extends React.Component<AllProps, State> {
 export default withRouter(Component);
 ```
 
-Juste like in JavaScript (JS), we wrap our component definition with
+Just like in JavaScript (JS), we wrap our component definition with
 `withRouter`. Then, we use type composition in order to create a new `AllProps`
 type which is our `Props` **and** the ones exported by React Router. This
 allows us to access `this.props.location` without any problem.

--- a/src/content/posts/santa-christmas-locker.md
+++ b/src/content/posts/santa-christmas-locker.md
@@ -99,13 +99,13 @@ finally:
 
 We can see that the encryption process uses an LFSR logic.
 
-An LFSR (for **L**inear **F**eedback **S**hift **R**egisters) can, in this
-implementation, be described as :
+An LFSR (for **L**inear **F**eedback **S**hift **R**egister) can, in this
+implementation, be described as:
 
-* A 32 bits register (see `lfsr_size` variable). The choice of 32 bits is convenient because it is the size of an integer.
+* A 32-bit register (see `lfsr_size` variable). The choice of 32 bits is convenient because it is the size of an integer.
 * Its initial state (initial value of the 32 bits), as defined by the user in `argv[1]`
 * A bunch of operations are made with the state of the LFSR (`self.state = (self.state >> 1) | newbit`)
-* The output of those operations become the next state of the register and is used in the next cycles
+* The output of those operations becomes the next state of the register and is used in the next cycles
 
 Here, each state is used to generate a byte, called stream (with the method
 `get_key_stream`) that will then be used to XOR a byte of the input file.
@@ -130,7 +130,7 @@ by XORing the byte `%` with the first encrypted byte.
 The issue here is that there are multiple initial states of the LFSR that can
 generate this initial stream.
 
-So what we can do is try every possibilities of initial states which generate
+So what we can do is try every possible initial state that generates
 the correct stream for the first 4 bytes of the pdf. If an initial state can
 be valid during four cycles, we can assume that it will be valid for all the
 rest of the file.
@@ -189,6 +189,6 @@ Which outputs:
 ```
 
 We can now launch the `shift_encrypt.py` script with this value and get the
-original PDF file, in which we can see :
+original PDF file, in which we can see:
 
 ![FLAG](/assets/santa/locker/flag.png)

--- a/src/content/posts/santa-jacques.md
+++ b/src/content/posts/santa-jacques.md
@@ -31,8 +31,8 @@ Let's start by downloading and extracting the provided `.zip` file:
 ```
 
 The `.pyc` file is some Python bytecode. It is not human readable so let's
-use some [online Python decompiler](https://python-decompiler.com/) to retrive
-the actual code source of what looks to be a Python ransomware.
+use some [online Python decompiler](https://python-decompiler.com/) to retrieve
+the actual source code of what looks to be a Python ransomware.
 
 ## The Ransomware
 
@@ -73,7 +73,7 @@ if __name__ == '__main__':
 ```
 
 The way the ransomware works is pretty simple. It has a list of usernames
-defined in `TARGET`. If the victim is one of them, it encrypts his files and
+defined in `TARGET`. If the victim is one of them, it encrypts their files and
 asks for a ransom.
 
 Let's focus on the encryption process:
@@ -123,10 +123,10 @@ def lock_file(path):
 We can observe multiple interesting things:
 
 1. The key used for encryption is the MD5 hash value of the victim username.
-We can also see the declaration of an AES cipher in EBC mode ( `AES.new(key, 1)`)
+We can also see the declaration of an AES cipher in ECB mode ( `AES.new(key, 1)`)
 2. We can see that a variable `IV` is defined. An Initialization vector is used
 in AES CBC mode which means that this function is implementing its own AES CBC
-encryption. The IV is set to a random 16 bytes value.
+encryption. The IV is set to a random 16-byte value.
 3. There is a request to what should be a C&C (useless for our case)
 4. The encryption algorithm: for each 16 bytes block of the file to encrypt,
 we xor it with the IV and we encrypt the result with the AES ECB cipher defined
@@ -140,15 +140,15 @@ This algorithm is beautifully represented in this Wikipedia schema:
 ## The problem
 
 We can uncipher every block in the `.hack` file except the first one, as it
-is the IV that was initialized to a random 16 bytes value.
+is the IV that was initialized to a random 16-byte value.
 
-But luckily we can bypass this! We know that we want to retrieve a JPG files. Thus, we could try to guess the first plaintext block based on the standard header of the JPG format. Let's try with:
+But luckily we can bypass this! We know that we want to retrieve a JPG file. Thus, we could try to guess the first plaintext block based on the standard header of the JPG format. Let's try with:
 
 ```
 \xff\xd8\xe0\x00\x10\x4a\x46\x49\x46\x00\x01\x01\x01\x00\x48\x00
 ```
-An other problem is that we should try all targeted usernames as key. But
-let's make some guess and consider that the key is `Jack Sheerack` (because
+Another problem is that we should try all targeted usernames as keys. But
+let's make a guess and consider that the key is `Jack Sheerack` (because
 of the challenge name). We will check the unciphered files generated with
 this key first.
 
@@ -207,8 +207,8 @@ Version: ImageMagick 6.9.10-67 Q16 x86_64 2019-10-04 https://imagemagick.org
 identify: Corrupt JPEG data: 18 extraneous bytes before marker 0xfe `/tmp/out-Jack Sheerack.jpg' @ warning/jpeg.c/JPEGWarningHandler/389.
 ```
 
-Thats a good thing! Our JPG is corrupted. How is that a good thing? Well now
-we know that it is almost valid ! If I try the same thing on a generated file
+That's a good thing! Our JPG is corrupted. How is that a good thing? Well now
+we know that it is almost valid! If I try the same thing on a generated file
 with the key `Jack Ma`, `identify` simply doesn't work:
 
 ```

--- a/src/content/posts/santa-nsar.md
+++ b/src/content/posts/santa-nsar.md
@@ -109,7 +109,7 @@ lang     c++
 ...
 ```
 
-It's an ELF 64 bits binary coded in C++ for the x86 architecture. It's now
+It's an ELF 64-bit binary coded in C++ for the x86 architecture. It's now
 time to launch IDA.
 
 The main function of the program consists of the multiple input prompts we
@@ -128,7 +128,7 @@ std::deque<std::fpos<__mbstate_t>,std::allocator<std::fpos<__mbstate_t>>>::deque
 std::deque<std::fpos<__mbstate_t>,std::allocator<std::fpos<__mbstate_t>>>::deque(&QUEUE_DOUBLE_E_2);
 ```
 
-We can divide the rest of the function in three main parts...
+We can divide the rest of the function into three main parts...
 
 ## Creation of the nsar header
 
@@ -183,7 +183,7 @@ For each file:
 3. Save the current position in the output buffer in the first deque `QUEUE_DOUBLE_E_1` 
 4. Write an integer (4 bytes) to the output file
 
-We can know start to tell the format of the header:
+We can now start to tell the format of the header:
 
 ```
 NSAR + 0x0 * 12 + filename1 + 0x0 + 4bytesInteger + filename2 + 0x0 + 4bytesInteger + ... 
@@ -255,7 +255,7 @@ Some explanations:
 *What does `gzwrite` do ?*
 
 At first I thought that it wouldn't compress anything because we use
-`gzwrite` to write one byte at the time. To check if my assumption was
+`gzwrite` to write one byte at a time. To check if my assumption was
 correct, I created a new NSAR archive containing only a `toast.pdf` file.
 Thanks to what we've learnt so far, we can tell the length of the
 corresponding archive header: `len("NSAR") + 12 + len("toast.pdf") + 1 + 4 = 30`
@@ -270,7 +270,7 @@ corresponding archive header: `len("NSAR") + 12 + len("toast.pdf") + 1 + 4 = 30`
 We can see that the body of the NSAR file starts with `1f 8b 08` which are
 the first bytes of the gzip file format.
 
-So it appear that `gzwrite` is using a buffer to store all the written
+So it appears that `gzwrite` is using a buffer to store all the written
 input and wait for `gzclose` to compress it and write it to the output
 file.
 
@@ -299,7 +299,7 @@ while ( (unsigned __int8)std::operator!=(&beg, &endd) )
 integer after a filename in NSAR header), go to it in the output file and pop
 the value from the deque.
 2. take the first value of the SECOND deque (which points to the beginning of
-the corresponding file content before compression) and stores it in the
+the corresponding file content before compression) and store it in the
 current position in the output buffer.
 
 And tada! We now know how the NSAR file format works:
@@ -353,7 +353,7 @@ def get_fileinfos(content: bytes) -> Tuple[str, int]:
     return filename, offset
 ```
 
-We can now open the file and read all header:
+We can now open the file and read the whole header:
 
 ```python
 with open("/tmp/archive.nsar", "rb") as f:
@@ -373,7 +373,7 @@ while True:
 ```
 
 We now have a dictionary `files` containing all archived files, their offset
-and their length in uncompressed body.
+and their length in the uncompressed body.
 
 ### Uncompress the body
 
@@ -393,8 +393,8 @@ content = content[:header_size] + c
 
 ### Getting the key
 
-We know that the body is XORed repetively with a key given by the chall
-creator. And we also know that if `a ^ b = c`, then `a ^ c = b`
+We know that the body is XORed repetitively with a key given by the chall
+creator. And we also know that if `a ^ b = c`, then `a ^ c = b`.
 
 Thanks to that property, we will be able to retrieve the key because we know
 a part of the plaintext that has been encrypted: the first bytes of the
@@ -402,7 +402,7 @@ header of the png format for example.
 
 To get the key, we will XOR the first bytes of the encrypted png files with
 the first bytes of png header. We will then be able to retrieve parts of the
-keys (as it is a repetitive xor) and finally get the complete key.
+key (as it is a repetitive xor) and finally get the complete key.
 
 Here is a function to check the part of key used at the beginning of an
 encrypted png:
@@ -448,7 +448,7 @@ Possible part of key cr37_KEYs_iS_^
 Possible part of key My_sUp3Rcr37_X
 ```
 
-We can know assemble the complete key used for encryption: `Th1s_iS_My_sUp3R_Secr37_KEY`.
+We can now assemble the complete key used for encryption: `Th1s_iS_My_sUp3R_Secr37_KEY`.
 
 ### Extract files
 

--- a/src/content/posts/so-stealthy.md
+++ b/src/content/posts/so-stealthy.md
@@ -9,17 +9,17 @@ d'équipes.
 
 ![Enoncé de l'épreuve](/assets/sostealthy/intro.png)
 
-Le scénario : une équipe réponse incident a fait une capture d'un réseau
+Le scénario : une équipe de réponse à incident a fait une capture d'un réseau
 infecté et c'est à nous de retrouver le **logiciel malveillant** qui a
 circulé.
 
 On commence par télécharger le fichier `suspicious.pcap` et on le charge
 dans Wireshark. Le fichier est trop volumineux pour qu'on se fasse chaque
 entrée à la main, du coup je scroll un peu au hasard et je fais des
-*Clique droit > Suivre > Flux TCP* de temps en temps mais rien ne me saute
+*Clic droit > Suivre > Flux TCP* de temps en temps mais rien ne me saute
 aux yeux, il va falloir des **filtres**...
 
-En scrollant, j'ai remarqué qu'il y avait des **connections HTTP**. Un filtre
+En scrollant, j'ai remarqué qu'il y avait des **connexions HTTP**. Un filtre
 qui marche assez bien quand on est dans un scénario d'infection est
 le suivant : `http contains function`. En effet, `function` est un mot clé
 permettant de déclarer une fonction en **Javascript** et ce **langage est
@@ -30,18 +30,18 @@ souvent utilisé comme vecteur d'infection**.
 On a deux entrées qui ressortent. La première ne nous intéresse pas du tout,
 c'est une page de warning genre "Attention, nous enregistrons vos cookies".
 Il se trouve que cette page embarque du Javascript de tracking, ce qui
-explique qu'on l'ai recupérée dans nos filets.
+explique qu'on l'ait récupérée dans nos filets.
 
-En revanche, quand on fait un *Clique droit > Suivre > Flux HTTP* sur la
+En revanche, quand on fait un *Clic droit > Suivre > Flux HTTP* sur la
 deuxième, on tombe sur **un gros bloc de Javascript un peu obfusqué** :
 
 ![Wireshark paquet intéressant](/assets/sostealthy/packet.png)
 
 _**Note** : On peut imaginer beaucoup d'autres variantes de ce filtre pour
 identifier du Javascript. Par exemple, le mot clé `function` n'est
-aujourd'hui plus du tout requis pour déclaré une fonction. Ainsi, il peut
-etre intéressant de matcher sur des éléments de syntaxe plus modernes comme
-`) => ` (bout de de déclaration en arrow function) ou bien `async`._
+aujourd'hui plus du tout requis pour déclarer une fonction. Ainsi, il peut
+être intéressant de matcher sur des éléments de syntaxe plus modernes comme
+`) => ` (bout de déclaration en arrow function) ou bien `async`._
 
 Voici le code brut, pas encore retravaillé :
 
@@ -237,15 +237,15 @@ try {
 }
 ```
 
-C'est une obfusquation assez "polie". Voici ce qu'il y a à corriger :
+C'est une obfuscation assez "polie". Voici ce qu'il y a à corriger :
 
   * La fonction `setversion` n'a pas de corps et n'est jamais appelée. On
   peut donc la retirer.
   * La fonction `debug` n'a pas de corps mais elle est appelée et prend
-  ce qui semble etre un message d'erreur en paramètre. Je lui ajoute
+  ce qui semble être un message d'erreur en paramètre. Je lui ajoute
   donc un corps affichant ce paramètre sur la sortie d'erreur. Dans le pire
   des cas, j'aurai un autre message d'erreur m'indiquant que l'objet pris
-  en paramètre ne peut etre automatiquement converti en `String`.
+  en paramètre ne peut être automatiquement converti en `String`.
   * Les noms de variable ne sont pas explicites. Je les renomme via les
   expressions régulières de Vim selon ma compréhension du code.
   * On peut aussi éventuellement corriger l'indentation et le formatage.
@@ -467,7 +467,7 @@ _**Note** : D'un point de vue méthodologique, **il n'est pas très malin
 de faire des modifications sur un code obfusqué avant de l'avoir exécuté
 au moins une fois** afin de valider son fonctionnement. En effet, on risque
 de casser le code en cherchant à le rendre plus lisible. Sauf que si on ne
-sait pas ce que ce code est censé faire, on a plus de **point de comparaison**
+sait pas ce que ce code est censé faire, on n'a plus de **point de comparaison**
 nous permettant de savoir si le code n'est pas fonctionnel dans l'absolu ou
 si c'est nous qui l'avons cassé._
 
@@ -478,10 +478,10 @@ car on ne sait pas **pour quel moteur Javascript a été écrit ce code** et don
 quels éléments syntaxiques il supporte. Il faut rendre le code explicite
 sans risquer d'altérer son fonctionnement._
 
-Il s'agit d'un **wrapper autour d'un composant Active X**. La grosse chaine de
+Il s'agit d'un **wrapper autour d'un composant Active X**. La grosse chaîne de
 caractères en **base64** est en fait le programme qui est décodé à la volée
 puis chargé et exécuté. Les appels à l'API Active X sont assez explicites.
-En revanche, j'ai été perturbé ces deux lignes là :
+En revanche, j'ai été perturbé par ces deux lignes-là :
 
 ```js
 // Call some method, we'll see that later
@@ -493,7 +493,7 @@ dynamicInvokation.Joh8achoo1aepahjeiy9();
 La variable `dynamicInvokation` représente ici le programme en cours
 d'exécution. **Deux méthodes avec des noms pas du tout explicites sont
 appelées** et pour l'instant il est assez difficile de prédire leur
-fonctionnement. On en reparlera plus tard. Il en va de meme pour la variable
+fonctionnement. On en reparlera plus tard. Il en va de même pour la variable
 `namespace`.
 
 J'ai ensuite essayé **d'exécuter le code**. En faisant quelques recherches, je
@@ -503,37 +503,37 @@ Windows et **j'autorise IE à exécuter tous les composants Active X**.
 
 Je charge le script via une page HTML et :
 
-![Le crackme apparait](/assets/sostealthy/please.png)
+![Le crackme apparaît](/assets/sostealthy/please.png)
 
-Une boite de dialogue qui nous demande un mot de passe... Il va donc falloir
-analyse le programme Active X. Voilà ce qu'on a lorsqu'on décode le base64 :
+Une boîte de dialogue qui nous demande un mot de passe... Il va donc falloir
+analyser le programme Active X. Voilà ce qu'on a lorsqu'on décode le base64 :
 
-![On reconnait du PE](/assets/sostealthy/pe.png)
+![On reconnaît du PE](/assets/sostealthy/pe.png)
 
-Le script `decode.js` ne fait qu'afficher l'ensemble des chaines base64, une
+Le script `decode.js` ne fait qu'afficher l'ensemble des chaînes base64, une
 fois concaténées.
 
-On reconnait **du PE** : `MZ`, `PE`, `This program cannot be run in DOS
+On reconnaît **du PE** : `MZ`, `PE`, `This program cannot be run in DOS
 mode.`...
 
 Je redirige la sortie vers un fichier mais `file` ne semble pas
 identifier le PE. Il détecte une police de caractères à la place. Le programme
-doit etre une sorte d'archive Active X.  J'utilise donc Foremost pour
+doit être une sorte d'archive Active X. J'utilise donc Foremost pour
 **extraire une DLL** :
 
 ![On extrait une DLL](/assets/sostealthy/extract.png)
 
 Je voulais charger la DLL dans IDA mais un pote m'a alors parlé de
 [dnSpy](https://github.com/0xd4d/dnSpy). C'est un outil pour analyser du
-.NET compilé et c'est plutot le feu.
+.NET compilé et c'est plutôt le feu.
 
 dnSpy est assez simple d'utilisation : on se balade dans les objets et
-les structures de données comme dans un explorateur de fichier. Aussi, super
+les structures de données comme dans un explorateur de fichiers. Aussi, super
 utile, **on peut aller chercher des cross references** et répondre super
 facilement à des questions genre : quelle fonction utilise cette variable ?
 Ou bien, quelle fonction initialise cette variable ? On en profite pour
-remarquer que le contenu de la variable que j'ai nommé `namespace` plus
-haute est alors présente de partout. ;)
+remarquer que le contenu de la variable que j'ai nommée `namespace` plus
+haut est alors présent partout. ;)
 
 On se balade un peu et on tombe rapidement sur la **routine de vérification**
 du mot de passe :
@@ -544,16 +544,16 @@ Admettons trois suites d'octets : A, B, C. A est passé en paramètre à la
 fonction.
 
 Pour chaque octet de la suite B, on récupère son homologue dans la suite A.
-On XOR les deux octets puis on compare le résulat à l'octet correspondant
+On XOR les deux octets puis on compare le résultat à l'octet correspondant
 dans la suite C. Si le résultat ne correspond pas, on se prend un message
 d'erreur. Sinon, on continue. Si on arrive à la fin de la routine, alors
 le mot de passe est correct.
 
-En bref, **c'est un bete XOR**. Le programme se sert de notre entrée (A) comme
+En bref, **c'est un bête XOR**. Le programme se sert de notre entrée (A) comme
 d'une clé et XOR de la donnée (B) avec. Si cette donnée correspond avec ce qui
 est attendu (C), on est bon.
 
-XOR est symétrique. Ainsi, **si on connait B et C, on peut retrouver A en les
+XOR est symétrique. Ainsi, **si on connaît B et C, on peut retrouver A en les
 XORant entre eux**.
 
 **C est facile à trouver**, il suffit de cliquer dessus dans dnSpy pour tomber
@@ -562,9 +562,9 @@ sur ce tableau :
 ![Tableau en dur](/assets/sostealthy/hardcoded.png)
 
 **Il ne nous reste plus qu'à trouver B**. Si on double clique dessus, on arrive
-sur **une référence** (référence/pointeur, je suis pas trop sur) et non un
-tableau en dur. B est donc construit **dynamiquement**.  DnSpy nous permet de
-trouver la fonction qui initialise B (*Clique droit sur une fonction >
+sur **une référence** (référence/pointeur, je suis pas trop sûr) et non un
+tableau en dur. B est donc construit **dynamiquement**. dnSpy nous permet de
+trouver la fonction qui initialise B (*Clic droit sur une fonction >
 Analyze*). Problème, **cette fonction n'est jamais appelée** dans le code :
 
 ![On analyse](/assets/sostealthy/analyze.png)
@@ -572,15 +572,15 @@ Analyze*). Problème, **cette fonction n'est jamais appelée** dans le code :
 Je récapitule. La routine de vérification `MeeBish...` utilise une variable
 appelée `Tai8Aip...` (B) qui est assignée dans la fonction `Aa6bi4...`.
 Cette fonction n'est jamais appelée (champ *Used by* vide). Regardons tout
-de meme sa définition :
+de même sa définition :
 
 ![Un simple setter](/assets/sostealthy/setter.png)
 
 La fonction est donc un simple setter qui récupère un paramètre pour en
-en extraire **les 22 derniers octets** et les assigner à B.
+extraire **les 22 derniers octets** et les assigner à B.
 
 La fonction n'est jamais appelée dans la DLL mais elle est appelée par le
-code Javascript que nous avons analysés précédemment ! Cette ligne, dont
+code Javascript que nous avons analysé précédemment ! Cette ligne, dont
 on ne comprenait pas trop l'utilité :
 
 ```js
@@ -590,7 +590,7 @@ dynamicInvokation.Aa6bi4uidan4shahSee9(bigBase64);
 
 Le nom de fonction correspond ! Et quel est le paramètre passé ? Le programme
 chiffré en base64... **La variable B correspond donc aux 22 derniers caractères
-du programme lui meme, une fois chiffré en base64**. Soit :
+du programme lui-même, une fois chiffré en base64**. Soit :
 
 ![Les octets convoités](/assets/sostealthy/bytes.png)
 

--- a/src/content/posts/what-makes-an-engineer-senior.md
+++ b/src/content/posts/what-makes-an-engineer-senior.md
@@ -99,7 +99,7 @@ feels easy is the day you've stopped getting better.
 ## Seniority is not management
 
 A very obvious and expensive mistake I've made myself is to promote great
-engineers to a management position. "He's been here five years, He's senior,
+engineers to a management position. "He's been here five years, he's senior,
 let's give him a team." **It's a great way to lose a strong engineer and
 manufacture a struggling manager in a single move...**
 
@@ -125,8 +125,8 @@ The difference is the kind of leadership:
   They lead because people choose to follow their judgment, not because they
   have to.
 
-Fortunately, most well structured companies operate on some version of this
-dual track framework. But when your startup is small and everyone does a bit of
+Fortunately, most well-structured companies operate on some version of this
+dual-track framework. But when your startup is small and everyone does a bit of
 everything, it's easy to confuse seniority and management.
 
 So seniority does NOT mean management. But, and this is the nuance that

--- a/src/content/posts/z3-intro.md
+++ b/src/content/posts/z3-intro.md
@@ -13,11 +13,11 @@ années) plus tard, il ressort avec **un système solution** de l'équation.
 ## Un monde de contraintes
 
 Ces équations, ce sont **des contraintes**. On peut exprimer beaucoup de choses
-avec des **opérateurs mathématiques** et les **structures de controle** d'un
-langage. Avec z3, il est facile de traduire des contraintes du genre "trouve
-moi une suite de 5 nombres entiers commençant à 13 et membres de la table de 7,
+avec des **opérateurs mathématiques** et les **structures de contrôle** d'un
+langage. Avec z3, il est facile de traduire des contraintes du genre "trouve-moi
+une suite de 5 nombres entiers commençant à 13 et membres de la table de 7,
 chacun étant au moins le double du précédent mais jamais plus de son triple, la
-somme de ces 5 nombres donnant un résultat multiple de 44". Si il existe bien
+somme de ces 5 nombres donnant un résultat multiple de 44". S'il existe bien
 une suite de 5 nombres qui vérifient toutes ces contraintes, z3 les trouvera.
 On dit alors que z3 fournit **un modèle**.
 
@@ -36,12 +36,12 @@ Sum: 440
 ```
 
 Certes, cet exemple est un peu inutile mais pas si éloigné de ce qu'on fait
-lorqu'on résout des crackmes avec z3. Le code est [disponible
+lorsqu'on résout des crackmes avec z3. Le code est [disponible
 ici](/assets/z3/z3_demo.py).
 
 ![constraints](/assets/z3/constraints_everywhere.jpg)
 
-[z3 est un projet de Microsoft](https://github.com/Z3Prover/z3). Le coeur est
+[z3 est un projet de Microsoft](https://github.com/Z3Prover/z3). Le cœur est
 développé en C++ et des **bindings** pour plusieurs langages sont disponibles.
 On se concentrera ici sur le **binding Python** qui est le plus répandu.
 
@@ -103,15 +103,15 @@ tard, on a **la flemme** et en plus on a trop picolé. Bon, commençons par rés
 ce que l'on sait :
 
   * Un flag fait 10 caractères
-  * A chaque caractère du flag correspond un nombre entre 0 et 66
+  * À chaque caractère du flag correspond un nombre entre 0 et 66
       tous deux inclus
   * Un flag valide vérifie une routine de calcul connue
   * La somme calculée doit être égale à 332867
-  * Il y a surement beaucoup de flags valides mais un seul suffit
+  * Il y a sûrement beaucoup de flags valides mais un seul suffit
 
 Et plusieurs solutions permettent de **résoudre ce problème** :
 
-  * Faire de la magie noire sur papier et sortir un flag de nul part en
+  * Faire de la magie noire sur papier et sortir un flag de nulle part en
       résolvant les équations à la main
   * Générer un dictionnaire de flags et tenter de les valider en exploitant la
       routine connue (bruteforce de gros porc en fait)
@@ -127,7 +127,7 @@ Pour faire du z3 avec Python, **il faut** :
   * D'autres trucs parfois, mais ça c'est la base
 
 Commençons par installer z3. Il existe des bindings pour Python 2 et 3 et on
-peut tous deux les installer avec pip. Nous allons faire du Python 2, donc :
+peut les installer tous les deux avec pip. Nous allons faire du Python 2, donc :
 
 ```
 ➜  ~ pip install z3-solver
@@ -161,11 +161,11 @@ final = ''
 s = Solver()
 ```
 
-On a récupéré la longeur du flag ainsi que `tab` dans le code original. Le type
+On a récupéré la longueur du flag ainsi que `tab` dans le code original. Le type
 `intVector` est apporté par z3, c'est simplement **un genre de liste** de `n`
 nombres entiers que le framework peut manipuler. `flag` représente donc les 10
 nombres inconnus qui donneront des caractères. `sums` représente les 10 sommes
-associés.
+associées.
 
 En effet, **chaque nombre à trouver est relié au précédent via une somme**. On
 sait également que chaque nombre a une valeur **entre 0 et 66** et que la somme
@@ -192,7 +192,7 @@ s.add(sums[n - 1] == 332867)
 Ce petit bout de code illustre bien toute la puissance de z3 : **il n'y a
 aucune différence entre le code source que l'on est en train d'écrire et les
 données (inconnues, contraintes...) que l'on manipule**. Le tout se confond et
-cela permet d'utilier la flexibilité de Python dans la rédaction même de nos
+cela permet d'utiliser la flexibilité de Python dans la rédaction même de nos
 contraintes.
 
 Enfin, on laisse z3 travailler :
@@ -211,12 +211,12 @@ else:
 ```
 
 La méthode `s.check()` sert à vérifier si z3 peut trouver au moins un modèle
-vérifiant les contraintes posées (`unsat`, pour *unsatisfied* est une valeur
+vérifiant les contraintes posées (`unsat`, pour *unsatisfied*, est une valeur
 apportée par z3). Si c'est le cas, on peut appeler la méthode `s.model()` qui
 renvoie ce modèle. Le modèle est encore une fois un genre de liste. Chaque
 élément de la liste n'est pas une valeur mais **un objet qui peut être manipulé
-par z3**. On utilise alors des méthodes tels que `m[f].as_long()` pour effecter
-une conversion en valeur brute.  On remarque alors que **les index utilisés**
+par z3**. On utilise alors des méthodes telles que `m[f].as_long()` pour effectuer
+une conversion en valeur brute. On remarque alors que **les index utilisés**
 pour parcourir le modèle sont en fait **les inconnues** que
 nous avons posées.
 
@@ -249,9 +249,9 @@ else:
     print "No solution found."
 ```
 
-A chaque fois qu'un modèle est trouvé, on rajoute une contrainte
+À chaque fois qu'un modèle est trouvé, on rajoute une contrainte
 supplémentaire : tous les caractères du prochain flag devront être différents
-des précédents.  Il est bien sur possible de générer encore plus de flags avec
+des précédents. Il est bien sûr possible de générer encore plus de flags avec
 des contraintes moins restrictives du type `s.add(Or(flag[0] != m[flag[0]]))`
 (seul le premier caractère doit être différent).
 
@@ -295,11 +295,11 @@ Le code complet est [disponible ici](/assets/z3/z3_js_challenge.py).
 ## Le mot d'la fin
 
 z3 est donc un logiciel puissant qui se prête très bien à la résolution de
-crackmes. La phase de reverse en elle même ne change pas vraiment, il faut
+crackmes. La phase de reverse en elle-même ne change pas vraiment, il faut
 toujours avoir une bonne compréhension de la routine utilisée par le crackme
 afin de la poser dans z3. En revanche, la rédaction d'un keygen est beaucoup
 plus facile et on élimine tout bruteforce. On peut aussi utiliser z3 en
-intéractif pour résoudre rapidement de petits problèmes dans la résolution
+interactif pour résoudre rapidement de petits problèmes dans la résolution
 d'une épreuve.
 
 z3 est un projet qui commence à être bien à la mode dans le milieu de la

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -157,7 +157,7 @@ const title = `${SITENAME} — Resume`;
             <p>
               Collaborated with various clients, such as Sony Music. Worked
               on a wide range of projects, from OCR pipelines in Python to
-              large scale web scraping in JavaScript.
+              large-scale web scraping in JavaScript.
             </p>
           </section>
         </section>
@@ -174,12 +174,12 @@ const title = `${SITENAME} — Resume`;
 
           <section>
             <h3>MSc in Computational Intelligence</h3>
-            <p class="meta">University Of Kent (United Kingdom) — 2020</p>
+            <p class="meta">University of Kent (United Kingdom) — 2020</p>
           </section>
 
           <section>
             <h3>Certificate of Proficiency in English (C2)</h3>
-            <p class="meta">University Of Cambridge — 2015</p>
+            <p class="meta">University of Cambridge — 2015</p>
           </section>
         </section>
 
@@ -268,7 +268,7 @@ const title = `${SITENAME} — Resume`;
         <div class="resume-print">
           <p>
             🖥️ This resume is made for the web! Please, visit the live version
-            at lucas.zip/resume .
+            at lucas.zip/resume.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Full proofreading pass over every page and blog post on the site. **Corrections only** — no content, structure, or styling changes. 45 files, 448 lines changed, all in place.

## What was fixed

**French** (course pages, CTF write-ups, `h25-js`)
- Missing circumflexes: `connaitre`, `chaine`, `apparait`, `dépot`, `surement`, `maitrisées`, `plutot`, `bete`, `grace`, `taton`
- Missing hyphens: `qu'est ce qui`, `est ce que`, `n'est ce pas`, `ces endroits là`, `lui même`, `débrouillez vous`, `dites nous`, `peut être`, `soit disant`
- Missing capital accents: `A` → `À`, `Ecrire` → `Écrire`, `Epreuve` → `Épreuve` (18×), `Ca` → `Ça`
- Agreement: `implémenté` → `implémentée`, `utilisé` → `utilisée`, `associés` → `associées`, `ancré` → `ancrés`, `investit` → `investie`, `des première années` → `premières`
- Verb forms: `fourni` → `fournit`, `ammène` → `amène`, `demander` → `demandée`, `chercher` → `cherche`, `souhaiterai` → `souhaiterait`, `risquerai` → `risquerais`, `Faison` → `Faisons`, `nous as` → `nous a`, `à été` → `a été`
- Elision: `si il` → `s'il`, `de Asaf` → `d'Asaf`, `de Olivier` → `d'Olivier`
- Typos: `exression`, `connection`, `offets`, `évoquateur`, `complêtement`, `permi`, `ect.`, `Mémotechnique`, `inaceptables`, `traditionnellment`, `imporante`, `longeur`, `résulat`, `d'utilier`, `inplémente`, `féérique`, `Exercie`

**English** (CTF write-ups, guides)
- Subject-verb agreement: `payloads crashes`, `there is 254 layers`, `script demonstrate`, `modules also help`, `output become`
- `its` / `it's` (5×), `a` / `an`, `Providing that` → `Provided that`
- Anglicism `allows to` → `allows us to` (8×)
- Hyphenation: `well structured`, `dual track`, `right hand side`, `client side`, `large scale`, `Higher Order Component`, `16 bytes value`, `32 bits register`
- Typos: `viewver`, `desinged`, `realease`, `suprised`, `explicitely`, `steganograpy`, `emmediately`, `readble`, `CRFL`, `EBC`, `ultimaletly`, `shaddy`, `dictionnary`, `searchs`, `unusal`, `stoped`, `retrive`, `loot`, `Juste`, `Thats`, `applicaion`
- `substracting X to Y` → `subtracting X from Y`, `we didn't didn't`, `pour en en extraire`

## Non-orthographic slips fixed along the way
- Duplicated list number (`3.` twice) in the Pelican guide
- Heading level `#` → `##` in `2019-reverse-01-teacher`
- Garbled `$ ucyLocker` → `$ucyLocker` and `(mal, qui le plus)` → `(mal, qui plus est)`
- Python module `request` → `requests` in `h25-js`
- `String.repeat()` described as a static method (it is an instance method)
- `fg` described as listing background jobs → `jobs`

## Deliberately left alone
- UK/US spelling variants (`generalise` vs `catalog`, `customise`, `analyse`, `behaviour`)
- Generic use of `auteur`

## Not included
The 7 Journal entries and `telegram-library-agent.md` are not yet committed to `master`, so their corrections could not go in a corrections-only PR. Four fixes are pending there and are listed in the job report.

## Verification
`npm run build` — 0 errors, 50 pages built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)