### PR TITLE
Pin tsconfigRootDir so agent worktrees stop breaking lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,15 @@
+import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import astro from 'eslint-plugin-astro'
 import globals from 'globals'
+
+// Agent worktrees live in .claude/worktrees/, each a full checkout with its
+// own tsconfig.json. typescript-eslint then finds several candidate roots and
+// refuses to guess, failing every file with "multiple candidate
+// TSConfigRootDirs". Ignoring the directory is not enough — the root is
+// resolved before file filtering — so pin it to this config's own location.
+const ROOT = fileURLToPath(new URL('.', import.meta.url))
 
 const styleRules = {
   semi: ['error', 'never', { beforeStatementContinuationChars: 'always' }],
@@ -10,13 +18,16 @@ const styleRules = {
 
 export default [
   {
-    ignores: ['dist/**', '.astro/**', '.vercel/**', 'node_modules/**'],
+    ignores: ['dist/**', '.astro/**', '.vercel/**', 'node_modules/**', '.claude/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,
   {
     languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: ROOT,
+      },
       globals: {
         ...globals.browser,
         ...globals.node,


### PR DESCRIPTION
`npm run lint` fails with 42 parsing errors whenever a worktree exists under `.claude/worktrees/`:

```
Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - /Users/lucas/Documents/code/blog.lucas.zip
 - /Users/lucas/Documents/code/blog.lucas.zip/.claude/worktrees/quote-styles
```

Each worktree is a full checkout carrying its own `tsconfig.json`, so typescript-eslint finds several candidate roots and refuses to guess.

## The fix

Pinning `tsconfigRootDir` to the config file's own directory is what actually resolves it — the root is resolved *before* file filtering, so adding `.claude/**` to `ignores` alone does not prevent the error. Both are included; the ignore additionally keeps ESLint from walking into those checkouts.

## Why now

I first reported this as transient, on the assumption the worktree would go away. It doesn't: `typo-fixes` was removed and `quote-styles` immediately took its place. Worktrees are routine in this repo, so this would have recurred with every new one.

CI never saw it — a fresh clone has no worktrees — which is precisely why it was worth fixing rather than waiting out. It only ever hurt local runs.

## Verification

`npm run lint` exits 0 with a worktree still present; `npm run build` exits 0. One file, +12 −1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)