### PR TITLE
Fix a grammar slip in the Au revoir là-haut quote

### DIFF
--- a/src/content/journal/au-revoir-la-haut.md
+++ b/src/content/journal/au-revoir-la-haut.md
@@ -51,7 +51,7 @@ Le meilleur personnage du roman, c'est Merlin :
 > rien, se leva et quitta le restaurant. Tout le monde fut pris de court, une
 > vraie bousculade, il fallut en hâte avaler sa dernière bouchée, vider son
 > verre, demander l'addition, vérifier la note, payer, on renversa des chaises,
-> on courut à la porte. Quand il arrivèrent dehors, Merlin était en train de
+> on courut à la porte. Quand ils arrivèrent dehors, Merlin était en train de
 > pisser sur la roue de la voiture. Avant de se rendre à la gare, il fallut
 > repasser au cimetière ramasser la sacoche de Merlin et ses registres. Son
 > train partant quarante minutes plus tard, pas question de rester plus


### PR DESCRIPTION
`Quand il arrivèrent dehors` — singular subject, plural verb. Corrected to `ils`.

## Where it came from

Not a transcription error. The epub in the Kavita library reads `il arrivèrent` too:

```
haises, on courut à la porte. Quand il arrivèrent dehors, Merlin était en train de pi
```

So this is a digitisation slip in that edition rather than anything introduced when the note was written up. Whether the printed book carries the same typo is not something the epub can answer.

## Note on the general rule

Quotes in journal entries are otherwise left exactly as published — the earlier proofreading pass deliberately corrected only the surrounding prose, never the quoted text, since altering a quotation misrepresents its author. This one is an explicit exception, requested and limited to a plainly ungrammatical agreement.

One character. `npm run build` and `npm run lint` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)