### PR TITLE
Pad blockquotes on both sides, not just behind the rule

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -255,9 +255,15 @@ li {
    colour were all saying the same thing; a hairline and a wide gutter say it
    once. It is the gap, not the weight of the rule, that sets the block apart —
    and journal entries quote whole paragraphs, which read badly in italic. */
+/* Padded on both sides, not just behind the rule: inset on the left alone, the
+   block stayed flush with the right edge of the column and read as lopsided —
+   most visibly on narrow screens, where the gutter is a large share of the
+   measure. The right padding has no rule to sit behind; it is there to make the
+   quote an inset block rather than a shifted one. */
 .content blockquote {
   margin: 2em 0;
   padding-left: 1.6em;
+  padding-right: 1.6em;
   border-left: 1px solid var(--color-faded-max);
 }
 


### PR DESCRIPTION
Follow-up to #63. Inset on the left alone, the quote stayed flush with the
right edge of the column and read as lopsided — most visibly on mobile, where
the gutter is a large share of the measure.

```css
.content blockquote {
  margin: 2em 0;
  padding-left: 1.6em;
  padding-right: 1.6em;   /* added */
  border-left: 1px solid var(--color-faded-max);
}
```

The right padding has no rule to sit behind; it is there so the quote reads as
an inset block rather than a shifted one.

### Checked

- `npm run lint` clean, `npm run build` exit 0
- Measured rather than eyeballed: padding is 27.2px on both sides at every
  width, text measure 584px on desktop, 302px at a 390px phone column

### One consequence worth knowing

`.content` justifies, and this narrows the quote's measure by 3.2em. On desktop
(584px) that is invisible. At a 390px phone the measure is now 302px, and the
justification opens up visible gaps on some lines.

Two one-line fixes if that bothers you, neither applied here:

```css
/* a — quotes ragged-right, body stays justified */
.content blockquote { text-align: left }

/* b — keep symmetry, buy back ~20px of measure on small screens */
@media screen and (max-width: 42em) {
  .content blockquote { padding-left: 1em; padding-right: 1em }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)