### PR TITLE
Trim the generated journal description

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,9 @@ exists.
 
 **Description fallback:** with no `description`, a media entry derives a
 French sentence from its metadata — `"Dune est un livre de Frank Herbert,
-paru en 1965. Je mettrais ★★★★☆ à ce livre."` — and a thought uses an excerpt
-of its body, falling back to its title if the body is empty. This exists so a
-shared journal link does not preview as the site-wide blurb about CTF
-writeups.
+paru en 1965. Note : 4/5."` — and a thought uses an excerpt of its body,
+falling back to its title if the body is empty. This exists so a shared
+journal link does not preview as the site-wide blurb about CTF writeups.
 
 The journal has its own feed at `/journal/rss.xml`; the main `/rss.xml` stays
 posts-only so subscribers to the essays are not flooded.

--- a/src/utils/journal.ts
+++ b/src/utils/journal.ts
@@ -136,11 +136,6 @@ const RELEASE_VERB: Record<MediaKind, string> = {
   film: 'sorti en',
 }
 
-const STATUS_SENTENCE: Record<Exclude<MediaData['status'], 'finished'>, string> = {
-  abandoned: "Je ne l'ai pas terminé.",
-  ongoing: 'Je suis encore dessus.',
-}
-
 const VOWEL = /^[aeiouâàéèêëîïôûùü]/i
 
 // "de Ursula" → "d'Ursula", but "réalisé par Andrei" is untouched. `h` is
@@ -150,11 +145,6 @@ const VOWEL = /^[aeiouâàéèêëîïôûùü]/i
 function joinCreator(preposition: string, creator: string): string {
   if (preposition === 'de' && VOWEL.test(creator)) return `d'${creator}`
   return `${preposition} ${creator}`
-}
-
-// "ce livre" but "cet album".
-function demonstrative(noun: string): string {
-  return VOWEL.test(noun) ? 'cet' : 'ce'
 }
 
 // schema.org type used as `itemReviewed` in the Review JSON-LD.
@@ -241,8 +231,14 @@ export function plain(text: string): string {
 
 /**
  * Describes an entry's metadata as one French sentence —
- * "Outer Wilds est un jeu vidéo de Mobius Digital, sorti en 2019." — used as
- * the OG and RSS description so a shared link previews as something useful.
+ * "Outer Wilds est un jeu vidéo de Mobius Digital, sorti en 2019. Note : 4/5."
+ * — used as the OG and RSS description so a shared link previews as something
+ * useful.
+ *
+ * Deliberately narrow: it states what the work is and what it scored, and
+ * nothing else. The link went because a preview blurb is rarely clickable
+ * where it lands, and the status ("Je ne l'ai pas terminé.") went with it —
+ * the page's own date line already says "Abandonné le …" where it matters.
  *
  * Returns null for a `thought`, which carries no metadata to describe.
  */
@@ -264,11 +260,7 @@ export function summarySentence(data: JournalData): string | null {
   }
   parts.push(`${opening}.`)
 
-  if (data.status !== 'finished') parts.push(STATUS_SENTENCE[data.status])
-  if (data.link) parts.push(`En savoir plus sur ${hostOf(data.link)}.`)
-  if (data.rating) {
-    parts.push(`Je mettrais ${ratingText(data.rating)} à ${demonstrative(noun)} ${noun}.`)
-  }
+  if (data.rating) parts.push(`Note : ${ratingText(data.rating)}.`)
 
   return parts.join(' ')
 }


### PR DESCRIPTION
The sentence derived from an entry's metadata feeds four places at once — the `<meta name="description">`, the `og:description` share preview, the RSS `<description>`, and the `description` field of the JSON-LD. It had grown three trailing clauses; two are gone and the third is shorter.

**Before**

> Grave est un film réalisé par Julia Ducournau, sorti en 2016. En savoir plus sur fr.wikipedia.org. Je mettrais 5/5 à ce film.

**After**

> Grave est un film réalisé par Julia Ducournau, sorti en 2016. Note : 5/5.

What changed and why:

- **"En savoir plus sur …"** — a preview blurb is rarely clickable where it lands, so the sentence named a destination the reader cannot follow. The link itself is untouched: still `↗ fr.wikipedia.org` in the masthead, still `sameAs` in the structured data.
- **The status sentence** — `"Je ne l'ai pas terminé."` and its `ongoing` counterpart both go. The entry's own date line already reads "Abandonné le …" / "En cours depuis le …" where that matters. No entry currently carries a non-`finished` status, so nothing rendered changes today.
- **The rating** — `"Je mettrais 5/5 à ce film."` becomes `"Note : 5/5."`, which also retires the demonstrative agreement it needed ("ce film" but "cet album").

Nothing else moves: the masthead, the star row, the listing and the art sentence are all untouched.

## QA

`npm run lint` and `npm run build` clean (0 errors; the `z is deprecated` warnings predate this). Verified against the built output that all eleven media entries and all four destinations agree, and that no old string survives anywhere in `dist`:

```
au-revoir-la-haut    Au revoir là-haut est un livre de Pierre Lemaitre, paru en 2013. Note : 4,5/5.
grave                Grave est un film réalisé par Julia Ducournau, sorti en 2016. Note : 5/5.
hysterie-collective  Hystérie collective est un livre de Lionel Shriver, paru en 2026. Note : 2,5/5.
les-vivants          Les vivants est un livre d'Ambre Chalumeau, paru en 2025. Note : 1/5.
karoly-ferenczy      19 œuvres de Károly Ferenczy et 4 autres artistes. Petit Palais, Paris.
```

Half-star ratings still read in French ("4,5/5"), and the art sentence is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)